### PR TITLE
Update Streamlit dependency to support navigation APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ pip install -r requirements.txt
 Exécutez l'application Streamlit avec la commande suivante :
 
 ```bash
-streamlit run Suivi_V1.py
+streamlit run streamlit_app.py
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pandas==1.5.0
 numpy==1.23.5
 plotly==5.9.0
 scikit-learn==1.2.0
-streamlit==1.23.1
+streamlit>=1.32.0
 statsmodels==0.14.0
 pmdarima==2.0.0
 scipy==1.10.1


### PR DESCRIPTION
## Summary
- raise the minimum supported Streamlit version to include the multi-page navigation APIs used by the app
- correct the README launch command to point at the existing `streamlit_app.py`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690782904814832990042c4f41b207ce