### PR TITLE
Fix CSV row loss and add diagnostics for Streamlit data pipeline

### DIFF
--- a/Suivi_V1.py
+++ b/Suivi_V1.py
@@ -9,6 +9,7 @@ import streamlit as st
 from app.utils import (
     DATA_URL,
     filter_by_dates,
+    get_data_diagnostics,
     get_date_range,
     load_data,
 )
@@ -56,12 +57,20 @@ def _load_dataset() -> None:
     with st.spinner("Chargement des données de poids..."):
         try:
             df = load_data(st.session_state["data_url"])
+            st.session_state["data_diagnostics"] = get_data_diagnostics(st.session_state["data_url"])
         except Exception as error:
             st.error(f"Erreur de chargement : {error}")
             st.exception(error)
             empty_df = pd.DataFrame(columns=["Date", "Poids (Kgs)"])
             st.session_state["raw_data"] = empty_df
             st.session_state["filtered_data"] = empty_df
+            st.session_state["data_diagnostics"] = {
+                "raw_rows": 0,
+                "valid_rows": 0,
+                "final_rows": 0,
+                "dropped_invalid_rows": 0,
+                "duplicate_date_rows": 0,
+            }
             return  # Don't st.stop() - let the page handle empty data
 
     st.session_state["raw_data"] = df

--- a/app/pages/Overview.py
+++ b/app/pages/Overview.py
@@ -18,6 +18,7 @@ from app.utils import (
     convert_df_to_csv,
     DATA_URL,
     detect_anomalies,
+    get_data_diagnostics,
     load_data,
 )
 from app.deploy import show_deployment_info
@@ -62,6 +63,7 @@ def _get_data():
     with st.spinner("Chargement des données de poids..."):
         try:
             df = load_data(data_url)
+            st.session_state["data_diagnostics"] = get_data_diagnostics(data_url)
         except Exception as error:
             st.error(f"Erreur critique lors du chargement : {error}")
             st.exception(error)
@@ -436,6 +438,17 @@ def main():
     col1.metric("Lignes", df.shape[0])
     col2.metric("Première Date", df["Date"].min().strftime("%d/%m/%Y") if not df.empty else "N/A")
     col3.metric("Dernière Date", df["Date"].max().strftime("%d/%m/%Y") if not df.empty else "N/A")
+
+    diagnostics = st.session_state.get("data_diagnostics")
+    if diagnostics:
+        st.caption(
+            "Pipeline CSV → mémoire: "
+            f"brut={diagnostics.get('raw_rows', 0)} | "
+            f"valides={diagnostics.get('valid_rows', 0)} | "
+            f"conservées={diagnostics.get('final_rows', 0)} | "
+            f"invalides ignorées={diagnostics.get('dropped_invalid_rows', 0)} | "
+            f"dates dupliquées détectées={diagnostics.get('duplicate_date_rows', 0)}"
+        )
     
     with st.expander("Aperçu des données brutes"):
         st.dataframe(df.tail(10))

--- a/app/utils.py
+++ b/app/utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Tuple
+from typing import Any, Dict, Iterable, Tuple
 
 import numpy as np
 import pandas as pd
@@ -23,6 +23,50 @@ PLOTLY_TEMPLATES = {
 }
 
 
+def _resolve_data_url(default_url: str) -> str:
+    """Resolve data URL from secrets when available, fallback otherwise."""
+    try:
+        return st.secrets.get("data_url", default_url)
+    except Exception:
+        return default_url
+
+
+def _read_csv_with_fallbacks(url: str) -> pd.DataFrame:
+    """Read CSV using resilient separator/encoding fallbacks."""
+    read_attempts = [
+        {"sep": None, "engine": "python", "decimal": ","},
+        {"sep": ",", "decimal": ","},
+        {"sep": ";", "decimal": ","},
+        {"sep": "\t", "decimal": ","},
+    ]
+    errors: list[str] = []
+    for options in read_attempts:
+        for encoding in ("utf-8", "utf-8-sig", "latin-1"):
+            try:
+                return pd.read_csv(url, encoding=encoding, **options)
+            except Exception as error:  # pragma: no cover - diagnostic fallback
+                errors.append(f"{encoding}/{options}: {type(error).__name__}")
+    raise RuntimeError(
+        "Impossible de parser le CSV (séparateur/encodage). "
+        f"Tentatives: {', '.join(errors[:5])}"
+    )
+
+
+def _normalise_expected_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalise common CSV header variants for required columns."""
+    normalised_cols = {}
+    for col in df.columns:
+        clean = str(col).replace("\ufeff", "").strip()
+        lowered = clean.lower()
+        if lowered in {"date", "dates"}:
+            normalised_cols[col] = "Date"
+        elif lowered in {"poids (kgs)", "poids", "poids(kg)", "poids (kg)"}:
+            normalised_cols[col] = "Poids (Kgs)"
+        else:
+            normalised_cols[col] = clean
+    return df.rename(columns=normalised_cols)
+
+
 @st.cache_data(ttl=300, show_spinner=False)
 def load_data(url: str = DATA_URL) -> pd.DataFrame:
     """Load and clean the dataset from the provided URL.
@@ -33,17 +77,19 @@ def load_data(url: str = DATA_URL) -> pd.DataFrame:
     caller can display a helpful message instead of crashing the Streamlit app.
     """
 
-    url = st.secrets.get("data_url", url)
+    url = _resolve_data_url(url)
 
     try:
-        df = pd.read_csv(url, decimal=",")
+        df = _read_csv_with_fallbacks(url)
     except (EmptyDataError, ParserError, ValueError) as error:
         raise RuntimeError("Le fichier de données est vide ou invalide.") from error
     except Exception as error:  # pragma: no cover
-        raise RuntimeError("Impossible de télécharger les données distantes.") from error
+        raise RuntimeError("Impossible de télécharger ou parser les données distantes.") from error
 
     if df.empty:
         raise RuntimeError("Aucune donnée disponible dans la source distante.")
+
+    df = _normalise_expected_columns(df)
 
     # Robust column cleaning
     if "Poids (Kgs)" not in df.columns or "Date" not in df.columns:
@@ -60,7 +106,6 @@ def load_data(url: str = DATA_URL) -> pd.DataFrame:
 
     df = (
         df.dropna(subset=["Poids (Kgs)", "Date"])
-        .drop_duplicates(subset=["Date"], keep="last")
         .sort_values("Date", ascending=True)
         .reset_index(drop=True)
     )
@@ -69,6 +114,39 @@ def load_data(url: str = DATA_URL) -> pd.DataFrame:
         raise RuntimeError("Les données récupérées ne contiennent aucune date/valeur valide.")
 
     return df
+
+
+@st.cache_data(ttl=300, show_spinner=False)
+def get_data_diagnostics(url: str = DATA_URL) -> Dict[str, Any]:
+    """Return row counts through the CSV -> DataFrame preparation pipeline."""
+    url = _resolve_data_url(url)
+    df_raw = _normalise_expected_columns(_read_csv_with_fallbacks(url))
+    raw_rows = int(df_raw.shape[0])
+
+    if "Poids (Kgs)" not in df_raw.columns or "Date" not in df_raw.columns:
+        return {
+            "raw_rows": raw_rows,
+            "valid_rows": 0,
+            "final_rows": 0,
+            "dropped_invalid_rows": raw_rows,
+            "duplicate_date_rows": 0,
+        }
+
+    df_work = df_raw.copy()
+    df_work["Poids (Kgs)"] = (
+        df_work["Poids (Kgs)"].astype(str).str.replace(",", ".").str.strip()
+    )
+    df_work["Poids (Kgs)"] = pd.to_numeric(df_work["Poids (Kgs)"], errors="coerce")
+    df_work["Date"] = pd.to_datetime(df_work["Date"], dayfirst=True, errors="coerce")
+    valid_df = df_work.dropna(subset=["Poids (Kgs)", "Date"])
+    final_df = valid_df.sort_values("Date", ascending=True).reset_index(drop=True)
+    return {
+        "raw_rows": raw_rows,
+        "valid_rows": int(valid_df.shape[0]),
+        "final_rows": int(final_df.shape[0]),
+        "dropped_invalid_rows": int(raw_rows - valid_df.shape[0]),
+        "duplicate_date_rows": int(valid_df.duplicated(subset=["Date"]).sum()),
+    }
 
 
 def apply_theme(fig: go.Figure, theme_name: str) -> go.Figure:
@@ -177,4 +255,3 @@ def predict_future_linear(
     
     predictions = model.predict(future_numeric.values.reshape(-1, 1))
     return pd.DataFrame({date_col: future_dates, "Prediction": predictions})
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,8 @@ from app.utils import (
     detect_anomalies,
     filter_by_dates,
     get_date_range,
+    get_data_diagnostics,
+    load_data,
 )
 
 
@@ -151,6 +153,50 @@ class TestGetDateRange:
         df = pd.DataFrame(columns=["Date", "Poids (Kgs)"])
         with pytest.raises(ValueError, match="DataFrame is empty"):
             get_date_range(df)
+
+
+class TestLoadDataPipeline:
+    """Tests around CSV loading and row conservation."""
+
+    def test_load_data_keeps_multiple_rows_same_date(self, monkeypatch):
+        """Rows sharing the same date must not be deduplicated."""
+        csv_df = pd.DataFrame(
+            {
+                "Date": ["01/01/2026", "01/01/2026", "02/01/2026"],
+                "Poids (Kgs)": ["80,1", "80,4", "80,0"],
+            }
+        )
+
+        def fake_read_csv(*args, **kwargs):
+            return csv_df.copy()
+
+        monkeypatch.setattr("app.utils.pd.read_csv", fake_read_csv)
+        load_data.clear()
+        out = load_data("fake://csv")
+
+        assert len(out) == 3
+        assert out["Date"].nunique() == 2
+
+    def test_data_diagnostics_counts_invalid_rows(self, monkeypatch):
+        """Diagnostics should expose dropped invalid rows and totals."""
+        csv_df = pd.DataFrame(
+            {
+                "Date": ["01/01/2026", "bad-date", "03/01/2026"],
+                "Poids (Kgs)": ["80,2", "81,0", ""],
+            }
+        )
+
+        def fake_read_csv(*args, **kwargs):
+            return csv_df.copy()
+
+        monkeypatch.setattr("app.utils.pd.read_csv", fake_read_csv)
+        get_data_diagnostics.clear()
+        stats = get_data_diagnostics("fake://csv")
+
+        assert stats["raw_rows"] == 3
+        assert stats["valid_rows"] == 1
+        assert stats["final_rows"] == 1
+        assert stats["dropped_invalid_rows"] == 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Users observed that not all rows from the CSV were displayed because the loading pipeline silently removed valid rows sharing the same `Date` value. 
- The change aims to preserve all valid rows, make CSV parsing more robust (separator/encoding/headers), and provide visible diagnostics to help debug source-format issues. 

### Description
- Stop deduplicating on `Date` in `load_data()` so multiple measurements on the same day are preserved and valid rows are not dropped. 
- Add resilient CSV reading with `_read_csv_with_fallbacks()` to try different separators and encodings and provide clearer errors when parsing fails. 
- Add `_normalise_expected_columns()` to normalise common header variants (BOM, `poids`, `Poids (Kgs)`, `Date`) to avoid column-name mismatches. 
- Add `get_data_diagnostics()` to report `raw_rows`, `valid_rows`, `final_rows`, `dropped_invalid_rows` and `duplicate_date_rows` so the app and developer can see pipeline losses. 
- Wire diagnostics into the app: store diagnostics in `st.session_state` during load and display the pipeline counters on the Overview page. 
- Add `_resolve_data_url()` to safely read `st.secrets` without raising in test environments. 
- Tests: add non-regression tests that reproduce prior row-loss behavior and validate diagnostics counts. 
- Files changed: `app/utils.py`, `Suivi_V1.py`, `app/pages/Overview.py`, `tests/test_utils.py`.

### Testing
- Ran the unit test suite with `pytest -q tests/test_utils.py`, and all tests passed (`13 passed`).
- New tests include `TestLoadDataPipeline` that asserts multiple rows with the same `Date` are preserved and that diagnostics counts invalid rows correctly (these tests succeeded).
- Note: network access to the live Google Sheets export is blocked in this environment, so tests operate with synthetic fixtures and the diagnostics helper; the change is validated by unit tests and a local reproduction script comparing before/after row counts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27258fb5883298fcae8fcbe20ba1c)