### PR TITLE
Add robust CSV parsing, data diagnostics, and preserve duplicate-date rows; wire diagnostics into UI

### DIFF
--- a/Suivi_V1.py
+++ b/Suivi_V1.py
@@ -56,9 +56,6 @@ def _load_dataset() -> None:
     with st.spinner("Chargement des données de poids..."):
         try:
             df = load_data(st.session_state["data_url"])
-            diagnostics_loader = getattr(app_utils, "get_data_diagnostics", None)
-            if callable(diagnostics_loader):
-                st.session_state["data_diagnostics"] = diagnostics_loader(st.session_state["data_url"])
         except Exception as error:
             st.error(f"Erreur de chargement : {error}")
             st.exception(error)
@@ -76,6 +73,24 @@ def _load_dataset() -> None:
 
     st.session_state["raw_data"] = df
     st.session_state["filtered_data"] = df
+
+    diagnostics_loader = getattr(app_utils, "get_data_diagnostics", None)
+    if callable(diagnostics_loader):
+        try:
+            st.session_state["data_diagnostics"] = diagnostics_loader(st.session_state["data_url"])
+        except Exception as diagnostics_error:
+            st.warning(
+                "Données chargées, mais les diagnostics sont indisponibles. "
+                "Réessayez avec « Recharger les données »."
+            )
+            st.session_state["data_diagnostics"] = {
+                "raw_rows": int(len(df)),
+                "valid_rows": int(len(df)),
+                "final_rows": int(len(df)),
+                "dropped_invalid_rows": 0,
+                "duplicate_date_rows": int(df.duplicated(subset=["Date"]).sum()) if "Date" in df.columns else 0,
+                "error": str(diagnostics_error),
+            }
 
 
 def _configure_sidebar() -> None:

--- a/Suivi_V1.py
+++ b/Suivi_V1.py
@@ -89,8 +89,8 @@ def _load_dataset() -> None:
                 "final_rows": int(len(df)),
                 "dropped_invalid_rows": 0,
                 "duplicate_date_rows": int(df.duplicated(subset=["Date"]).sum()) if "Date" in df.columns else 0,
-                "error": str(diagnostics_error),
             }
+            st.session_state["data_diagnostics_error"] = str(diagnostics_error)
 
 
 def _configure_sidebar() -> None:

--- a/Suivi_V1.py
+++ b/Suivi_V1.py
@@ -6,13 +6,13 @@ import subprocess
 import pandas as pd
 import streamlit as st
 
-from app.utils import (
-    DATA_URL,
-    filter_by_dates,
-    get_date_range,
-    load_data,
-)
+from app import utils as app_utils
 from app.auth import check_password
+
+DATA_URL = app_utils.DATA_URL
+filter_by_dates = app_utils.filter_by_dates
+get_date_range = app_utils.get_date_range
+load_data = app_utils.load_data
 
 
 def _get_commit_sha() -> str:
@@ -56,12 +56,22 @@ def _load_dataset() -> None:
     with st.spinner("Chargement des données de poids..."):
         try:
             df = load_data(st.session_state["data_url"])
+            diagnostics_loader = getattr(app_utils, "get_data_diagnostics", None)
+            if callable(diagnostics_loader):
+                st.session_state["data_diagnostics"] = diagnostics_loader(st.session_state["data_url"])
         except Exception as error:
             st.error(f"Erreur de chargement : {error}")
             st.exception(error)
             empty_df = pd.DataFrame(columns=["Date", "Poids (Kgs)"])
             st.session_state["raw_data"] = empty_df
             st.session_state["filtered_data"] = empty_df
+            st.session_state["data_diagnostics"] = {
+                "raw_rows": 0,
+                "valid_rows": 0,
+                "final_rows": 0,
+                "dropped_invalid_rows": 0,
+                "duplicate_date_rows": 0,
+            }
             return  # Don't st.stop() - let the page handle empty data
 
     st.session_state["raw_data"] = df

--- a/app/pages/Overview.py
+++ b/app/pages/Overview.py
@@ -60,9 +60,6 @@ def _get_data():
     with st.spinner("Chargement des données de poids..."):
         try:
             df = load_data(data_url)
-            diagnostics_loader = getattr(app_utils, "get_data_diagnostics", None)
-            if callable(diagnostics_loader):
-                st.session_state["data_diagnostics"] = diagnostics_loader(data_url)
         except Exception as error:
             st.error(f"Erreur critique lors du chargement : {error}")
             st.exception(error)
@@ -76,6 +73,24 @@ def _get_data():
 
     st.session_state["raw_data"] = df
     st.session_state["filtered_data"] = df
+
+    diagnostics_loader = getattr(app_utils, "get_data_diagnostics", None)
+    if callable(diagnostics_loader):
+        try:
+            st.session_state["data_diagnostics"] = diagnostics_loader(data_url)
+        except Exception as diagnostics_error:
+            st.warning(
+                "Données chargées, mais les diagnostics sont indisponibles. "
+                "Réessayez avec « Recharger les données »."
+            )
+            st.session_state["data_diagnostics"] = {
+                "raw_rows": int(len(df)),
+                "valid_rows": int(len(df)),
+                "final_rows": int(len(df)),
+                "dropped_invalid_rows": 0,
+                "duplicate_date_rows": int(df.duplicated(subset=["Date"]).sum()) if "Date" in df.columns else 0,
+            }
+            st.session_state["data_diagnostics_error"] = str(diagnostics_error)
     return df.copy()
 
 

--- a/app/pages/Overview.py
+++ b/app/pages/Overview.py
@@ -10,17 +10,15 @@ import plotly.graph_objects as go
 import numpy as np
 import streamlit as st
 
-
-
-from app.utils import (
-    apply_theme,
-    calculate_moving_average,
-    convert_df_to_csv,
-    DATA_URL,
-    detect_anomalies,
-    load_data,
-)
+from app import utils as app_utils
 from app.deploy import show_deployment_info
+
+apply_theme = app_utils.apply_theme
+calculate_moving_average = app_utils.calculate_moving_average
+convert_df_to_csv = app_utils.convert_df_to_csv
+DATA_URL = app_utils.DATA_URL
+detect_anomalies = app_utils.detect_anomalies
+load_data = app_utils.load_data
 
 # Debug: show page path only if debug_mode is enabled
 if st.secrets.get("debug_mode", False):
@@ -62,6 +60,9 @@ def _get_data():
     with st.spinner("Chargement des données de poids..."):
         try:
             df = load_data(data_url)
+            diagnostics_loader = getattr(app_utils, "get_data_diagnostics", None)
+            if callable(diagnostics_loader):
+                st.session_state["data_diagnostics"] = diagnostics_loader(data_url)
         except Exception as error:
             st.error(f"Erreur critique lors du chargement : {error}")
             st.exception(error)
@@ -436,6 +437,17 @@ def main():
     col1.metric("Lignes", df.shape[0])
     col2.metric("Première Date", df["Date"].min().strftime("%d/%m/%Y") if not df.empty else "N/A")
     col3.metric("Dernière Date", df["Date"].max().strftime("%d/%m/%Y") if not df.empty else "N/A")
+
+    diagnostics = st.session_state.get("data_diagnostics")
+    if diagnostics:
+        st.caption(
+            "Pipeline CSV → mémoire: "
+            f"brut={diagnostics.get('raw_rows', 0)} | "
+            f"valides={diagnostics.get('valid_rows', 0)} | "
+            f"conservées={diagnostics.get('final_rows', 0)} | "
+            f"invalides ignorées={diagnostics.get('dropped_invalid_rows', 0)} | "
+            f"dates dupliquées détectées={diagnostics.get('duplicate_date_rows', 0)}"
+        )
     
     with st.expander("Aperçu des données brutes"):
         st.dataframe(df.tail(10))

--- a/app/utils.py
+++ b/app/utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Tuple
+from typing import Any, Dict, Iterable, Tuple
 
 import numpy as np
 import pandas as pd
@@ -23,6 +23,50 @@ PLOTLY_TEMPLATES = {
 }
 
 
+def _resolve_data_url(default_url: str) -> str:
+    """Resolve data URL from secrets when available, fallback otherwise."""
+    try:
+        return st.secrets.get("data_url", default_url)
+    except Exception:
+        return default_url
+
+
+def _read_csv_with_fallbacks(url: str) -> pd.DataFrame:
+    """Read CSV using resilient separator/encoding fallbacks."""
+    read_attempts = [
+        {"sep": None, "engine": "python", "decimal": ","},
+        {"sep": ",", "decimal": ","},
+        {"sep": ";", "decimal": ","},
+        {"sep": "\t", "decimal": ","},
+    ]
+    errors: list[str] = []
+    for options in read_attempts:
+        for encoding in ("utf-8", "utf-8-sig", "latin-1"):
+            try:
+                return pd.read_csv(url, encoding=encoding, **options)
+            except Exception as error:  # pragma: no cover - diagnostic fallback
+                errors.append(f"{encoding}/{options}: {type(error).__name__}")
+    raise RuntimeError(
+        "Impossible de parser le CSV (séparateur/encodage). "
+        f"Tentatives: {', '.join(errors[:5])}"
+    )
+
+
+def _normalise_expected_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalise common CSV header variants for required columns."""
+    normalised_cols = {}
+    for col in df.columns:
+        clean = str(col).replace("\ufeff", "").strip()
+        lowered = clean.lower()
+        if lowered in {"date", "dates"}:
+            normalised_cols[col] = "Date"
+        elif lowered in {"poids (kgs)", "poids", "poids(kg)", "poids (kg)"}:
+            normalised_cols[col] = "Poids (Kgs)"
+        else:
+            normalised_cols[col] = clean
+    return df.rename(columns=normalised_cols)
+
+
 @st.cache_data(ttl=300, show_spinner=False)
 def load_data(url: str = DATA_URL) -> pd.DataFrame:
     """Load and clean the dataset from the provided URL.
@@ -33,17 +77,19 @@ def load_data(url: str = DATA_URL) -> pd.DataFrame:
     caller can display a helpful message instead of crashing the Streamlit app.
     """
 
-    url = st.secrets.get("data_url", url)
+    url = _resolve_data_url(url)
 
     try:
-        df = pd.read_csv(url, decimal=",")
+        df = _read_csv_with_fallbacks(url)
     except (EmptyDataError, ParserError, ValueError) as error:
         raise RuntimeError("Le fichier de données est vide ou invalide.") from error
     except Exception as error:  # pragma: no cover
-        raise RuntimeError("Impossible de télécharger les données distantes.") from error
+        raise RuntimeError("Impossible de télécharger ou parser les données distantes.") from error
 
     if df.empty:
         raise RuntimeError("Aucune donnée disponible dans la source distante.")
+
+    df = _normalise_expected_columns(df)
 
     # Robust column cleaning
     if "Poids (Kgs)" not in df.columns or "Date" not in df.columns:
@@ -60,7 +106,6 @@ def load_data(url: str = DATA_URL) -> pd.DataFrame:
 
     df = (
         df.dropna(subset=["Poids (Kgs)", "Date"])
-        .drop_duplicates(subset=["Date"], keep="last")
         .sort_values("Date", ascending=True)
         .reset_index(drop=True)
     )
@@ -69,6 +114,39 @@ def load_data(url: str = DATA_URL) -> pd.DataFrame:
         raise RuntimeError("Les données récupérées ne contiennent aucune date/valeur valide.")
 
     return df
+
+
+@st.cache_data(ttl=300, show_spinner=False)
+def get_data_diagnostics(url: str = DATA_URL) -> Dict[str, Any]:
+    """Return row counts through the CSV -> DataFrame preparation pipeline."""
+    url = _resolve_data_url(url)
+    df_raw = _normalise_expected_columns(_read_csv_with_fallbacks(url))
+    raw_rows = int(df_raw.shape[0])
+
+    if "Poids (Kgs)" not in df_raw.columns or "Date" not in df_raw.columns:
+        return {
+            "raw_rows": raw_rows,
+            "valid_rows": 0,
+            "final_rows": 0,
+            "dropped_invalid_rows": raw_rows,
+            "duplicate_date_rows": 0,
+        }
+
+    df_work = df_raw.copy()
+    df_work["Poids (Kgs)"] = (
+        df_work["Poids (Kgs)"].astype(str).str.replace(",", ".").str.strip()
+    )
+    df_work["Poids (Kgs)"] = pd.to_numeric(df_work["Poids (Kgs)"], errors="coerce")
+    df_work["Date"] = pd.to_datetime(df_work["Date"], dayfirst=True, errors="coerce")
+    valid_df = df_work.dropna(subset=["Poids (Kgs)", "Date"])
+    final_df = valid_df.sort_values("Date", ascending=True).reset_index(drop=True)
+    return {
+        "raw_rows": raw_rows,
+        "valid_rows": int(valid_df.shape[0]),
+        "final_rows": int(final_df.shape[0]),
+        "dropped_invalid_rows": int(raw_rows - valid_df.shape[0]),
+        "duplicate_date_rows": int(valid_df.duplicated(subset=["Date"]).sum()),
+    }
 
 
 def apply_theme(fig: go.Figure, theme_name: str) -> go.Figure:
@@ -177,4 +255,3 @@ def predict_future_linear(
     
     predictions = model.predict(future_numeric.values.reshape(-1, 1))
     return pd.DataFrame({date_col: future_dates, "Prediction": predictions})
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,8 @@ from app.utils import (
     detect_anomalies,
     filter_by_dates,
     get_date_range,
+    get_data_diagnostics,
+    load_data,
 )
 
 
@@ -151,6 +153,50 @@ class TestGetDateRange:
         df = pd.DataFrame(columns=["Date", "Poids (Kgs)"])
         with pytest.raises(ValueError, match="DataFrame is empty"):
             get_date_range(df)
+
+
+class TestLoadDataPipeline:
+    """Tests around CSV loading and row conservation."""
+
+    def test_load_data_keeps_multiple_rows_same_date(self, monkeypatch):
+        """Rows sharing the same date must not be deduplicated."""
+        csv_df = pd.DataFrame(
+            {
+                "Date": ["01/01/2026", "01/01/2026", "02/01/2026"],
+                "Poids (Kgs)": ["80,1", "80,4", "80,0"],
+            }
+        )
+
+        def fake_read_csv(*args, **kwargs):
+            return csv_df.copy()
+
+        monkeypatch.setattr("app.utils.pd.read_csv", fake_read_csv)
+        load_data.clear()
+        out = load_data("fake://csv")
+
+        assert len(out) == 3
+        assert out["Date"].nunique() == 2
+
+    def test_data_diagnostics_counts_invalid_rows(self, monkeypatch):
+        """Diagnostics should expose dropped invalid rows and totals."""
+        csv_df = pd.DataFrame(
+            {
+                "Date": ["01/01/2026", "bad-date", "03/01/2026"],
+                "Poids (Kgs)": ["80,2", "81,0", ""],
+            }
+        )
+
+        def fake_read_csv(*args, **kwargs):
+            return csv_df.copy()
+
+        monkeypatch.setattr("app.utils.pd.read_csv", fake_read_csv)
+        get_data_diagnostics.clear()
+        stats = get_data_diagnostics("fake://csv")
+
+        assert stats["raw_rows"] == 3
+        assert stats["valid_rows"] == 1
+        assert stats["final_rows"] == 1
+        assert stats["dropped_invalid_rows"] == 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Improve resilience of CSV loading against varied separators and encodings and surface pipeline diagnostics to help debug data quality issues.
- Preserve rows that share the same `Date` instead of silently deduplicating them to avoid losing user-supplied measurements.
- Expose diagnostics to the Streamlit session and UI so users can quickly see how many rows were parsed/validated/dropped.

### Description

- Reworked imports to use `from app import utils as app_utils` and re-exported commonly used helpers (e.g. `load_data`, `apply_theme`) where needed.
- Replaced fragile CSV loading with helpers `
_resolve_data_url`, `
_read_csv_with_fallbacks`, and `
_normalise_expected_columns` and updated `load_data` to use those fallbacks and to stop deduplicating by `Date`.
- Added cached `get_data_diagnostics` that returns row counts across the CSV→DataFrame pipeline (raw, valid, final, dropped invalid rows, duplicate-date rows).
- Piped diagnostics into the Streamlit session (`st.session_state['data_diagnostics']`) and rendered a compact caption in the `Overview` page and stored diagnostics in the main `Suivi_V1` loader.
- Added new unit tests in `tests/test_utils.py` covering preservation of duplicate-date rows and verifying diagnostics counts, and updated tests to import `get_data_diagnostics` and `load_data`.

### Testing

- Ran the test module with `pytest tests/test_utils.py` which executed the updated unit tests for `calculate_moving_average`, `filter_by_dates`, `get_date_range`, and the new `TestLoadDataPipeline` cases; all tests passed.
- The tests exercise CSV fallback parsing via `monkeypatch` on `pd.read_csv` and verify that `load_data` preserves multiple rows with the same date and that `get_data_diagnostics` reports expected counts, both assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27258fb5883298fcae8fcbe20ba1c)