### PR TITLE
Avoid Streamlit startup ImportError by lazy-loading anomaly dependencies

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -3,15 +3,13 @@
 from __future__ import annotations
 
 from typing import Any, Dict, Iterable, Tuple
+import importlib
 
 import numpy as np
 import pandas as pd
 from pandas.errors import EmptyDataError, ParserError
 import plotly.graph_objects as go
 import streamlit as st
-
-from scipy import stats
-from sklearn.ensemble import IsolationForest 
 
 DATA_URL = "https://docs.google.com/spreadsheets/d/1qPhLKvm4BREErQrm0L38DcZFG4a-K0msSzARVIG_T_U/export?format=csv"
 
@@ -181,11 +179,32 @@ def detect_anomalies(
         return df
 
     if method == "IsolationForest":
-        model = IsolationForest(contamination=contamination, random_state=42)
-        df["Anomalies"] = model.fit_predict(df[["Poids (Kgs)"]]) == -1
-    else:
-        df["Z_score"] = np.abs(stats.zscore(df["Poids (Kgs)"]))
+        sklearn_spec = importlib.util.find_spec("sklearn.ensemble")
+        if sklearn_spec is None:
+            # Graceful fallback when scikit-learn is not available at runtime
+            # (e.g., partial installs on constrained environments).
+            method = "Z-score"
+        else:
+            sklearn_ensemble = importlib.import_module("sklearn.ensemble")
+            model = sklearn_ensemble.IsolationForest(
+                contamination=contamination,
+                random_state=42,
+            )
+            df["Anomalies"] = model.fit_predict(df[["Poids (Kgs)"]]) == -1
+            return df
+
+    if method == "Z-score":
+        series = pd.to_numeric(df["Poids (Kgs)"], errors="coerce")
+        std = float(series.std(ddof=0))
+        if std == 0 or np.isnan(std):
+            df["Z_score"] = 0.0
+        else:
+            mean = float(series.mean())
+            df["Z_score"] = ((series - mean) / std).abs()
         df["Anomalies"] = df["Z_score"] > z_threshold
+    else:
+        # Unknown method: default to no anomalies rather than raising.
+        df["Anomalies"] = False
     return df
 
 


### PR DESCRIPTION
### Motivation
- The app could fail at import time when optional heavy packages (`scipy`, `scikit-learn`) are missing, causing Streamlit to show a redacted `ImportError` instead of a usable page. 
- Make anomaly detection resilient so the app can start and degrade gracefully while keeping basic functionality.

### Description
- Remove eager imports of `scipy` and `sklearn` from the module top-level and add `importlib`-based lazy loading in `app/utils.py` so optional dependencies are only required when used. 
- When `method == "IsolationForest"` the code now attempts to import `sklearn.ensemble` at runtime and uses `IsolationForest` only if available; otherwise it falls back to `Z-score`. 
- Replace the previous SciPy `zscore` usage with a NumPy/Pandas implementation that handles zero or NaN standard deviation defensively and computes `Z_score` and `Anomalies`. 
- Add defensive behavior for unknown `method` values to return `Anomalies = False` instead of raising an error.

### Testing
- Ran unit tests with `pytest -q` which completed successfully: `13 passed in 2.52s`. 
- Verified module import works in the current environment with `python -c "import app.utils; print(hasattr(app.utils, 'detect_anomalies'))"` which returned successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e278455d0483298188117e7fc0e5fa)