### PR TITLE
Fix Streamlit password callback KeyError

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -48,7 +48,8 @@ def check_password() -> bool:
 
     def password_entered():
         """Checks whether a password entered by the user is correct."""
-        if hmac.compare_digest(st.session_state["password"], correct_password):
+        entered_password = str(st.session_state.get("password", ""))
+        if hmac.compare_digest(entered_password, correct_password):
             st.session_state["password_correct"] = True
             st.session_state.pop("password", None)
         else:


### PR DESCRIPTION
### Motivation
- The Streamlit app raised a `KeyError` during the password callback because the code directly indexed `st.session_state["password"]`, which can be absent during reruns or when the widget state is missing.

### Description
- Change `password_entered()` in `app/auth.py` to read the entered password with `st.session_state.get("password", "")` and cast to `str` before comparing with `hmac.compare_digest`.
- Preserve existing behavior: set `st.session_state["password_correct"] = True` and remove the `password` key on success, otherwise set it to `False`.
- The change is a small safety hardening to avoid runtime crashes while keeping authentication logic unchanged.

### Testing
- Ran `pytest -q`, all tests passed (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e279f0271883298731a410cf13bb52)