### PR TITLE
feat: refonte Suivi V2 — UX modulaire, qualité des données et prévisions robustes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## 2025-11-07
-- Durcissement du chargement des données (gestion des erreurs réseau, nettoyage des doublons).
-- Fallback de navigation pour les versions de Streamlit sans `st.Page`.
-- Ajout de la configuration `.streamlit/` et d'un exemple de secrets.
-- Épinglage des dépendances dans `requirements.txt`.
-- Mise à jour de la documentation projet (`README.md`).
+## 2026-04-17
+- Refonte V2: nouvelle navigation 5 pages (Dashboard/Journal/Prévisions/Insights/Paramètres).
+- Refactor modulaire `app/core/*` et `app/ui/*`.
+- Ajout fallback upload CSV local si Google Sheets indisponible.
+- Ajout couche qualité des données + score + diagnostics.
+- Ajout backtesting walk-forward et leaderboard des baselines.
+- Ajout intervalles de prédiction (SARIMAX + quantile regression), ETA prudente, plateau 14j/30j.
+- Ajout tests unitaires core + smoke tests Streamlit AppTest.

--- a/README.md
+++ b/README.md
@@ -1,228 +1,32 @@
-# Suivi_V1 🏋️
+# Suivi_V1 → V2 (Streamlit)
 
-Application Streamlit interactive pour le **suivi, l'analyse et la prédiction de l'évolution du poids**, intégrant des modèles de machine learning et des techniques de séries temporelles.
+Application Streamlit de suivi du poids (français), orientée analyse statistique robuste et prévisions avec incertitude.
 
-[![Streamlit App](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://samirelhassani1998-suivi-v1-suivi-v1-knzeqy.streamlit.app/)
+## Nouveautés V2
+- Navigation pro en 5 espaces: **Dashboard, Journal, Prévisions, Insights, Paramètres**.
+- Journal éditable avec `st.data_editor`, validation (date/poids/doublons/aberrants) et export CSV.
+- Source par défaut Google Sheets (`st.secrets.data_url`) + fallback upload CSV local.
+- Backtesting walk-forward + leaderboard des baselines (last, MA7, MA14, drift).
+- Prévisions avec intervalles de prédiction (SARIMAX + régression quantile).
+- Détection de plateau (14j/30j), anomalies robustes (z-score robuste, option IsolationForest), ETA objectif prudente.
+- Architecture modulaire (`app/core`, `app/ui`) et tests unitaires + smoke tests Streamlit.
 
----
-
-## 📋 Table des matières
-
-- [Fonctionnalités](#-fonctionnalités)
-- [Architecture](#-architecture)
-- [Stack Technique](#-stack-technique)
-- [Installation](#-installation)
-- [Configuration](#%EF%B8%8F-configuration)
-- [Utilisation](#-utilisation)
-- [Déploiement](#-déploiement)
-- [Troubleshooting](#-troubleshooting)
-- [Ressources](#-ressources)
-
----
-
-## ✨ Fonctionnalités
-
-### 📊 Vue d'ensemble (Overview)
-- **Métriques clés** : Poids actuel, poids moyen, IMC, variation 7j/30j avec calcul intelligent de la date la plus proche
-- **Progression vers l'objectif** : Visualisation de l'avancement vers les objectifs personnalisés
-- **Graphiques interactifs** : Évolution du poids avec moyennes mobiles (simple ou exponentielle)
-- **Détection d'anomalies** : Identification des valeurs atypiques via Z-score ou IsolationForest
-- **Export CSV** : Téléchargement des données filtrées
-- **📊 Tendances** *(NEW)* : Indicateurs visuels de tendance (📉/📈/➡️) basés sur la moyenne mobile 7j/30j
-- **📅 Comparaison Hebdomadaire** *(NEW)* : Moyenne cette semaine vs semaine précédente avec évolution en %
-
-### 🤖 Modèles (Modeles)
-- **Comparaison de modèles ML** : Régression Linéaire vs Random Forest avec validation croisée temporelle
-- **Métriques de performance** : MSE, MAE, R² pour chaque modèle
-- **Jauge de progression** : Indicateur visuel vers les objectifs de poids
-- **Clustering K-Means** : Segmentation des données de poids en clusters
-- **Détection d'anomalies ML** : Identification via IsolationForest
-
-### 📈 Prédictions
-- **Régression linéaire** : Prévision avec intervalle de confiance configurable
-- **📊 Métriques de Confiance** *(NEW)* : R², MAE, RMSE avec indicateur de confiance (🟢 Haute / 🟡 Moyenne / 🔴 Faible)
-- **Décomposition STL** : Séparation tendance, saisonnalité et résidus
-- **SARIMA** : Modèle de prévision avec composantes saisonnières (avec spinner de chargement)
-- **Auto-ARIMA** : Sélection automatique des meilleurs paramètres avec `pmdarima` (avec spinner de chargement)
-- **Autocorrélation** : Visualisation ACF/PACF pour l'analyse des séries temporelles
-
----
-
-## 🏗 Architecture
-
-```
-Suivi_V1/
-├── Suivi_V1.py              # Point d'entrée principal
-├── app/
-│   ├── __init__.py
-│   ├── auth.py              # Module d'authentification par mot de passe
-│   ├── deploy.py            # Infos de déploiement
-│   ├── utils.py             # Fonctions utilitaires partagées
-│   └── pages/
-│       ├── Overview.py      # Page Vue d'ensemble
-│       ├── Modeles.py       # Page Comparaison des modèles
-│       └── Predictions.py   # Page Prédictions
-├── .streamlit/
-│   ├── config.toml          # Configuration Streamlit (thème, etc.)
-│   └── secrets.toml.example # Exemple de configuration des secrets
-├── tests/                   # Tests unitaires
-│   └── test_utils.py        # Tests de non-régression
-├── docs/                    # Documentation
-│   └── MODEL_CARD.md        # Carte de modèle ML (gouvernance)
-├── requirements.txt         # Dépendances Python
-├── runtime.txt              # Version Python pour le déploiement
-├── TECH_REPORT.md           # Rapport technique détaillé
-├── AUDIT.md                 # Notes d'audit
-└── CHANGELOG.md             # Historique des modifications
-```
-
-### Flux de données
-
-1. **Chargement** : Les données sont récupérées depuis Google Sheets via export CSV
-2. **Cache** : Mise en cache intelligente avec `st.cache_data` (TTL 5 min)
-3. **Filtrage** : Filtrage par plage de dates dans la sidebar
-4. **Traitement** : Calcul des moyennes mobiles, détection d'anomalies
-5. **Visualisation** : Graphiques Plotly avec thèmes personnalisables
-
----
-
-## 🔧 Stack Technique
-
-| Catégorie | Technologies |
-|-----------|-------------|
-| **Framework UI** | Streamlit 1.38+ |
-| **Visualisation** | Plotly Express, Plotly Graph Objects |
-| **Data Processing** | Pandas, NumPy |
-| **Machine Learning** | Scikit-learn (LinearRegression, RandomForest, KMeans, IsolationForest) |
-| **Time Series** | Statsmodels (STL, ARIMA, ACF/PACF), pmdarima (Auto-ARIMA) |
-| **Statistiques** | SciPy (Z-score) |
-| **Stockage** | Google Sheets (source), PyArrow (traitement) |
-
----
-
-## 💻 Installation
-
-### Prérequis
-
-- **Python** : 3.10 ou 3.11
-- **Accès réseau** : Connectivité vers Google Sheets
-
-### Installation locale
-
+## Exécution
 ```bash
-# 1. Cloner le dépôt
-git clone https://github.com/samirelhassani1998/Suivi_V1.git
-cd Suivi_V1
-
-# 2. Créer un environnement virtuel (recommandé)
-python -m venv venv
-source venv/bin/activate  # Linux/macOS
-# ou
-.\venv\Scripts\activate   # Windows
-
-# 3. Installer les dépendances
 pip install -r requirements.txt
+streamlit run Suivi_V1.py
+pytest -q
 ```
 
----
-
-## ⚙️ Configuration
-
-### Fichier de secrets
-
-Créez le fichier `.streamlit/secrets.toml` basé sur l'exemple fourni :
-
+## Secrets (exemple)
 ```toml
 [auth]
 required = true
-password = "votre_mot_de_passe"
+password = "mot_de_passe"
 
-# Optionnel : URL personnalisée pour les données
-# data_url = "https://..."
-
-# Optionnel : Mode debug (affiche les chemins de page)
-# debug_mode = false
+data_url = "https://.../export?format=csv"
 ```
 
-### Modes d'accès
-
-| Mode | Configuration | Description |
-|------|--------------|-------------|
-| **Protégé** | `required = true` + `password = "..."` | Mot de passe requis |
-| **Démo** | `required = false` | Accès libre sans authentification |
-
----
-
-## 🚀 Utilisation
-
-### Lancement local
-
-```bash
-streamlit run Suivi_V1.py
-```
-
-L'application sera accessible sur [http://localhost:8501](http://localhost:8501)
-
-### Paramètres de la sidebar
-
-- **Données** : Rechargement, filtrage par dates
-- **Affichage** : Thème Plotly (Dark, Light, Solar, Seaborn)
-- **Moyennes mobiles** : Type (Simple/Exponentielle) et fenêtre (1-30 jours)
-- **Objectifs** : 4 niveaux d'objectifs personnalisables
-- **Anomalies** : Méthode de détection et seuil Z-score
-- **Activité** : Suivi calorique (calories consommées/brûlées)
-
----
-
-## ☁️ Déploiement
-
-### Streamlit Community Cloud
-
-1. Poussez votre code sur GitHub
-2. Connectez-vous à [share.streamlit.io](https://share.streamlit.io)
-3. Déployez en pointant sur `Suivi_V1.py`
-4. Configurez les secrets dans **Settings → Secrets** :
-   ```toml
-   [auth]
-   required = true
-   password = "votre_mot_de_passe_secret"
-   ```
-
-### URL de l'application
-
-🔗 https://samirelhassani1998-suivi-v1-suivi-v1-knzeqy.streamlit.app/
-
----
-
-## 🔍 Troubleshooting
-
-| Problème | Cause possible | Solution |
-|----------|---------------|----------|
-| **Erreur réseau** | Connectivité Google Sheets | Vérifier firewall, configurer `data_url` dans secrets |
-| **`st.Page` manquant** | Streamlit < 1.31 | Mettre à jour : `pip install streamlit>=1.38` |
-| **Dépendances manquantes** | Environnement incomplet | Recréer venv et réinstaller requirements |
-| **Quota API dépassé** | Trop de requêtes Google | Utiliser source de données alternative |
-| **Calculs lents** | Gros dataset + Auto-ARIMA | Réduire la plage de dates, activer le cache |
-| **Erreur d'authentification** | Secrets non configurés | Configurer `.streamlit/secrets.toml` |
-
----
-
-## 📚 Ressources
-
-### Documentation officielle
-- [Streamlit Documentation](https://docs.streamlit.io/)
-- [Plotly Express](https://plotly.com/python/plotly-express/)
-- [Scikit-learn](https://scikit-learn.org/stable/)
-- [Statsmodels](https://www.statsmodels.org/)
-- [pmdarima (Auto-ARIMA)](https://alkaline-ml.com/pmdarima/)
-
-### Fichiers du projet
-- [TECH_REPORT.md](./TECH_REPORT.md) - Rapport technique détaillé
-- [CHANGELOG.md](./CHANGELOG.md) - Historique des modifications
-- [AUDIT.md](./AUDIT.md) - Notes d'audit du code
-
----
-
-## 📄 Licence
-
-Ce projet est sous licence MIT. Voir le fichier [LICENSE](./LICENSE) pour plus de détails.
+## Limites importantes
+- Les prévisions sont **informatives et non médicales**.
+- Si peu de données (< 14/20 points selon modèle), l'app affiche des avertissements et limite les sorties.

--- a/Suivi_V1.py
+++ b/Suivi_V1.py
@@ -1,178 +1,71 @@
-"""Entry point for the Streamlit multi-page application."""
+"""Entrée principale Streamlit - Suivi V2."""
 
 from __future__ import annotations
 
-import subprocess
 import pandas as pd
 import streamlit as st
 
-from app.utils import (
-    DATA_URL,
-    filter_by_dates,
-    get_data_diagnostics,
-    get_date_range,
-    load_data,
-)
 from app.auth import check_password
+from app.config import DATA_URL
+from app.core.data import clean_weight_dataframe, validate_journal
+from app.ui.theme import apply_global_theme
 
 
-def _get_commit_sha() -> str:
-    """Get the short commit SHA for version tracking."""
+@st.cache_data(ttl=300)
+def load_remote_csv(url: str) -> pd.DataFrame:
+    raw = pd.read_csv(url)
+    return clean_weight_dataframe(raw)
+
+
+def load_dataset() -> None:
+    """Charge Google Sheets, puis fallback CSV local si indisponible."""
+    data_url = st.secrets.get("data_url", DATA_URL)
+    st.session_state["data_url"] = data_url
+
     try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--short", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        return result.stdout.strip() or "unknown"
+        df = load_remote_csv(data_url)
+        st.session_state["data_source"] = "google_sheets"
     except Exception:
-        return "unknown"
+        st.warning("Source Google Sheets indisponible. Utilisez un CSV local pour continuer.")
+        uploaded = st.sidebar.file_uploader("Fallback CSV local", type=["csv"])
+        if uploaded is None:
+            df = st.session_state.get("raw_data", pd.DataFrame(columns=["Date", "Poids (Kgs)"]))
+            st.session_state["data_source"] = "session"
+        else:
+            local = pd.read_csv(uploaded)
+            report = validate_journal(local)
+            df = report.cleaned
+            st.session_state["data_source"] = "csv_local"
+            for warning in report.warnings:
+                st.info(warning)
+
+    st.session_state["raw_data"] = df.copy()
+    st.session_state["filtered_data"] = df.copy()
 
 
-st.set_page_config(page_title="Suivi & Analyses du Poids", layout="wide")
-
-st.markdown(
-    """
-    <style>
-    .reportview-container { font-family: 'Segoe UI', sans-serif; }
-    .sidebar .sidebar-content { background-image: linear-gradient(#2e7bcf, #2e7bcf); color: white; }
-    .stButton>button { background-color: #2e7bcf; color: white; border: none; }
-    .stMetric { font-size: 1.5rem; }
-    </style>
-    """,
-    unsafe_allow_html=True,
-)
-
-
-def _load_dataset() -> None:
-    """Load the dataset and store both raw and filtered versions."""
-    if "data_url" not in st.session_state:
-        st.session_state["data_url"] = st.secrets.get("data_url", DATA_URL)
-
-    if st.session_state.get("reload_requested"):
-        load_data.clear()
-        st.session_state.pop("reload_requested")
-
-    with st.spinner("Chargement des données de poids..."):
-        try:
-            df = load_data(st.session_state["data_url"])
-            st.session_state["data_diagnostics"] = get_data_diagnostics(st.session_state["data_url"])
-        except Exception as error:
-            st.error(f"Erreur de chargement : {error}")
-            st.exception(error)
-            empty_df = pd.DataFrame(columns=["Date", "Poids (Kgs)"])
-            st.session_state["raw_data"] = empty_df
-            st.session_state["filtered_data"] = empty_df
-            st.session_state["data_diagnostics"] = {
-                "raw_rows": 0,
-                "valid_rows": 0,
-                "final_rows": 0,
-                "dropped_invalid_rows": 0,
-                "duplicate_date_rows": 0,
-            }
-            return  # Don't st.stop() - let the page handle empty data
-
-    st.session_state["raw_data"] = df
-    st.session_state["filtered_data"] = df
-
-
-def _configure_sidebar() -> None:
-    """Setup sidebar controls and apply filtering to the dataset."""
-    st.sidebar.header("Paramètres Généraux")
-
+def sidebar_controls() -> None:
+    st.sidebar.header("Contrôles")
     if st.sidebar.button("Recharger les données"):
-        st.session_state["reload_requested"] = True
-        load_data.clear()
+        load_remote_csv.clear()
         st.rerun()
 
-    st.sidebar.selectbox(
-        "Choisir un thème",
-        ["Default", "Dark", "Light", "Solar", "Seaborn"],
-        key="theme",
-    )
-    st.sidebar.selectbox(
-        "Type de moyenne mobile",
-        ["Simple", "Exponentielle"],
-        key="ma_type",
-    )
-    st.sidebar.slider(
-        "Taille de la moyenne mobile (jours)",
-        1, 30,
-        st.session_state.get("window_size", 7),
-        key="window_size",
-    )
-
-    df = st.session_state.get("raw_data")
-    if df is not None and not df.empty:
-        try:
-            date_min, date_max = get_date_range(df)
-            date_range = st.sidebar.date_input(
-                "Sélectionnez une plage de dates",
-                (date_min, date_max),
-                key="date_range",
-            )
-            st.session_state["filtered_data"] = filter_by_dates(df, date_range)
-        except Exception as error:
-            st.sidebar.error(f"Erreur dates : {error}")
-            st.session_state["filtered_data"] = df
-    else:
-        st.session_state["filtered_data"] = df
-
-    st.sidebar.markdown("---")
-    st.sidebar.subheader("Objectifs et Infos Personnelles")
-    target1 = st.sidebar.number_input("Objectif 1 (Kgs)", value=st.session_state.get("target_weight_1", 95.0), key="target_weight_1")
-    target2 = st.sidebar.number_input("Objectif 2 (Kgs)", value=st.session_state.get("target_weight_2", 90.0), key="target_weight_2")
-    target3 = st.sidebar.number_input("Objectif 3 (Kgs)", value=st.session_state.get("target_weight_3", 85.0), key="target_weight_3")
-    target4 = st.sidebar.number_input("Objectif 4 (Kgs)", value=st.session_state.get("target_weight_4", 80.0), key="target_weight_4")
-    st.session_state["target_weights"] = (target1, target2, target3, target4)
-
-    height_cm = st.sidebar.number_input("Votre taille (cm)", value=st.session_state.get("height_cm", 182), key="height_cm")
-    st.session_state["height_m"] = height_cm / 100.0
-
-    st.sidebar.markdown("---")
-    st.sidebar.subheader("Anomalies & Activité")
-    st.sidebar.selectbox("Méthode de détection", ["Z-score", "IsolationForest"], key="anomaly_method")
-    st.sidebar.slider("Seuil Z-score", 1.0, 5.0, st.session_state.get("z_threshold", 2.0), step=0.5, key="z_threshold")
-
-    calories = st.sidebar.number_input("Calories consommées", min_value=0, value=st.session_state.get("calories", 2000), key="calories")
-    calories_burned = st.sidebar.number_input("Calories brûlées", min_value=0, value=st.session_state.get("calories_burned", 500), key="calories_burned")
-    st.sidebar.write("Bilan calorique :", calories - calories_burned, "kcal")
-
-    st.sidebar.markdown("---")
-    with st.sidebar.expander("État du système", expanded=False):
-        st.write(f"Streamlit: {st.__version__}")
-        st.write(f"Commit: {_get_commit_sha()}")
-        if "auth" in st.secrets or "password" in st.secrets:
-            st.success("Secrets: Configuré")
-        else:
-            st.warning("Secrets: Non configuré")
+    st.sidebar.caption(f"Source active: {st.session_state.get('data_source', 'n/a')}")
 
 
-# ============================================================
-# MAIN APPLICATION FLOW
-# ============================================================
+st.set_page_config(page_title="Suivi V2", layout="wide")
+apply_global_theme()
 
-# 1. Check auth FIRST
 if not check_password():
     st.stop()
 
-# 2. Load data
-_load_dataset()
+load_dataset()
+sidebar_controls()
 
-# 3. Setup sidebar
-_configure_sidebar()
-
-# 4. CRITICAL: Run navigation - this MUST be the main content
-#    Pages will render their own content. Do NOT add content after pg.run()!
-if hasattr(st, "Page") and hasattr(st, "navigation"):
-    pages = [
-        st.Page("app/pages/Overview.py", title="Vue d'ensemble", icon="📊"),
-        st.Page("app/pages/Modeles.py", title="Modèles", icon="🤖"),
-        st.Page("app/pages/Predictions.py", title="Prédictions", icon="📈"),
-    ]
-    pg = st.navigation(pages)
-    pg.run()  # <-- This executes the selected page script
-else:
-    st.error("Streamlit >= 1.31 requis pour st.navigation.")
-    st.stop()
+pages = [
+    st.Page("app/pages/Dashboard.py", title="Dashboard", icon="📊"),
+    st.Page("app/pages/Journal.py", title="Journal", icon="🧾"),
+    st.Page("app/pages/Predictions.py", title="Prévisions", icon="📈"),
+    st.Page("app/pages/Insights.py", title="Insights", icon="🔍"),
+    st.Page("app/pages/Settings.py", title="Paramètres", icon="⚙️"),
+]
+st.navigation(pages).run()

--- a/TECH_REPORT.md
+++ b/TECH_REPORT.md
@@ -1,58 +1,24 @@
-# Rapport Technique
+# TECH_REPORT — Suivi V2
 
-## 1. Causes racines et reproduction
-- **Erreur d'import `st.Page` sur Streamlit Cloud** : la plate-forme exécutait une
-  version < 1.38 de Streamlit, ne supportant pas `st.Page`/`st.navigation`.
-  Reproduit en lançant l'application avec une version plus ancienne (1.25) :
-  `AttributeError: module 'streamlit' has no attribute 'Page'`.
-- **Plantage lors du chargement des données** : aucune gestion d'erreurs autour
-  du Google Sheet. Toute indisponibilité réseau levait une exception Pandas non
-  interceptée, stoppant l'application.
-- **Thème Plotly invalide** : l'option "Solar" appelait `plotly_solar`, un
-  template inexistant -> `ValueError` dès que l'utilisateur sélectionnait le
-  thème.
+## Architecture
+- `app/core/data.py`: nettoyage, validation, qualité des données, stratégie de doublons.
+- `app/core/features.py`: lags, rolling stats, variation, IMC, bilan calorique.
+- `app/core/evaluation.py`: métriques (MAE/RMSE/MAPE/sMAPE/biais/directional accuracy), walk-forward.
+- `app/core/models.py`: modèles linéaires, arbres, boosting, quantiles.
+- `app/core/forecasting.py`: prévisions SARIMAX + quantile regression (intervalles).
+- `app/core/insights.py`: anomalies, plateau, ETA objectif.
+- `app/ui/components.py`: KPI, badges confiance, alertes, aides.
 
-## 2. Décisions techniques
-- Fixation des dépendances (Python 3.10/3.11) dans `requirements.txt` pour
-  assurer un déploiement reproductible sur Streamlit Cloud.
-- Gestion centralisée des erreurs dans `app/utils.load_data` avec conversion des
-  exceptions en `RuntimeError` et nettoyage systématique des données.
-- Fallback pour la navigation multipage : on conserve `st.navigation` quand il
-  est disponible et l'on affiche un message d'aide sinon (les versions
-  antérieures utilisent automatiquement le dossier `pages/`).
-- Ajout d'un thème Plotly valide (`plotly`) pour l'option "Solar" et harmonisait
-  la configuration `.streamlit/`.
-- Introduction d'un exemple de secrets et lecture optionnelle de `data_url`
-  depuis `st.secrets`.
+## Fiabilité statistique
+- Séparation explicite backtest vs in-sample.
+- Baselines obligatoires pour éviter les métriques optimistes.
+- Intervalles non-i.i.d. naïfs: SARIMAX CI et quantiles conditionnels.
 
-## 3. Tests effectués
-- **Installation** : tentative `pip install -r requirements.txt` (échoue dans
-  l'environnement de travail à cause d'un proxy 403, cf. sortie CLI). Les
-  versions choisies sont toutes disponibles sur PyPI avec roues précompilées.
-- **Exécution locale** : la commande `streamlit run streamlit_app.py` est à
-  relancer une fois les dépendances installées ; non exécutable ici à cause du
-  proxy bloquant l'accès au Google Sheet.
-- **Déploiement Cloud** : vérifier après merge que l'URL
-  https://samirelhassani1998-suivi-v1-suivi-v1-knzeqy.streamlit.app/ affiche le
-  bandeau "Suivi de l'Évolution du Poids" et que la navigation fonctionne. Une
-  capture du log de succès doit être ajoutée à la description de déploiement.
+## Résilience
+- Fallback CSV local si Google Sheets indisponible.
+- Gestion dataset vide/petit/mal formaté sans crash.
+- Persistance session + export CSV.
 
-## 4. Points de vigilance
-- **Quotas API Google Sheets** : un trop grand nombre de rafraîchissements peut
-  déclencher des limitations. En cas de besoin, configurer un `data_url` privé
-  via `st.secrets`.
-- **Consommation mémoire** : `statsmodels` et `pmdarima` peuvent dépasser les
-  limites Streamlit Cloud si le dataset grossit. Activer les caches et limiter
-  les fenêtres d'analyse en conséquence.
-- **Temps de calcul** : `auto_arima` et les validations croisées peuvent durer
-  plusieurs secondes ; la mise en cache est recommandée pour les scénarios à
-  forte fréquentation.
-- **Mises à jour de dépendances** : surveiller la compatibilité future de
-  `numpy`/`pmdarima` avant tout upgrade.
-
-## 5. Vérification post-déploiement
-1. Déployer depuis la branche principale.
-2. Ouvrir l'URL publique et confirmer l'absence d'erreurs dans les logs
-   Streamlit Cloud.
-3. Capturer le log de démarrage (onglet **Logs**) montrant `Running on port 8501`
-   et le lier à la description de déploiement.
+## Compatibilité
+- Python 3.10/3.11
+- Streamlit 1.38+

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,38 @@
+"""Configuration centralisée de l'application Suivi V2."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+DATA_URL: Final[str] = "https://docs.google.com/spreadsheets/d/1qPhLKvm4BREErQrm0L38DcZFG4a-K0msSzARVIG_T_U/export?format=csv"
+REQUIRED_COLUMNS: Final[tuple[str, ...]] = ("Date", "Poids (Kgs)")
+OPTIONAL_COLUMNS: Final[tuple[str, ...]] = (
+    "Calories consommées",
+    "Calories brûlées",
+    "Pas",
+    "Sommeil (heures)",
+    "Hydratation",
+    "Tour de taille",
+    "Body fat %",
+    "Notes",
+    "Condition de mesure",
+)
+ALL_COLUMNS: Final[tuple[str, ...]] = REQUIRED_COLUMNS + OPTIONAL_COLUMNS
+
+DUPLICATE_STRATEGIES: Final[tuple[str, ...]] = (
+    "garder_la_derniere",
+    "moyenne_journaliere",
+    "mediane_journaliere",
+)
+
+
+@dataclass(frozen=True)
+class AppDefaults:
+    """Valeurs par défaut modifiables via l'UI."""
+
+    height_cm: int = 182
+    target_weight: float = 80.0
+    confidence_level: float = 0.9
+    duplicate_strategy: str = "garder_la_derniere"
+    default_model: str = "ridge"

--- a/app/core/data.py
+++ b/app/core/data.py
@@ -1,0 +1,140 @@
+"""Chargement, validation et qualité des données."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from app.config import ALL_COLUMNS, REQUIRED_COLUMNS
+
+
+@dataclass
+class ValidationResult:
+    errors: list[str]
+    warnings: list[str]
+    cleaned: pd.DataFrame
+
+
+def _normalize_columns(df: pd.DataFrame) -> pd.DataFrame:
+    mapping: dict[str, str] = {}
+    for c in df.columns:
+        cleaned = str(c).replace("\ufeff", "").strip()
+        low = cleaned.lower()
+        if low in {"date", "dates"}:
+            mapping[c] = "Date"
+        elif low in {"poids", "poids (kg)", "poids(kg)", "poids (kgs)"}:
+            mapping[c] = "Poids (Kgs)"
+        else:
+            mapping[c] = cleaned
+    return df.rename(columns=mapping)
+
+
+def _parse_dates(values: pd.Series) -> pd.Series:
+    txt = values.astype(str).str.strip().str.replace("'", "", regex=False)
+    dt = pd.to_datetime(txt, errors="coerce", dayfirst=True)
+    miss = dt.isna()
+    if miss.any():
+        dt.loc[miss] = pd.to_datetime(txt.loc[miss], errors="coerce", dayfirst=False)
+    return dt
+
+
+def clean_weight_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Nettoie un dataframe en format standard sans mutation in-place."""
+    out = _normalize_columns(df.copy())
+    for col in ALL_COLUMNS:
+        if col not in out.columns:
+            out[col] = np.nan
+
+    out["Poids (Kgs)"] = pd.to_numeric(
+        out["Poids (Kgs)"].astype(str).str.replace(",", ".", regex=False),
+        errors="coerce",
+    )
+    out["Date"] = _parse_dates(out["Date"])
+    out = out.dropna(subset=["Date", "Poids (Kgs)"]).sort_values("Date").reset_index(drop=True)
+    return out[list(ALL_COLUMNS)]
+
+
+def validate_journal(df: pd.DataFrame) -> ValidationResult:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    normalized = _normalize_columns(df.copy())
+    for col in REQUIRED_COLUMNS:
+        if col not in normalized.columns:
+            errors.append(f"Colonne obligatoire absente: {col}")
+
+    cleaned = clean_weight_dataframe(normalized) if not errors else pd.DataFrame(columns=ALL_COLUMNS)
+    if not cleaned.empty:
+        invalid_weight = int((cleaned["Poids (Kgs)"] <= 0).sum())
+        if invalid_weight:
+            errors.append(f"{invalid_weight} ligne(s) avec poids <= 0")
+
+        duplicate_count = int(cleaned.duplicated(subset=["Date"]).sum())
+        if duplicate_count:
+            warnings.append(f"{duplicate_count} doublon(s) de date détecté(s)")
+
+        q1, q3 = cleaned["Poids (Kgs)"].quantile([0.25, 0.75])
+        iqr = q3 - q1
+        if iqr > 0:
+            low, high = q1 - 1.5 * iqr, q3 + 1.5 * iqr
+            outlier_count = int(((cleaned["Poids (Kgs)"] < low) | (cleaned["Poids (Kgs)"] > high)).sum())
+            if outlier_count:
+                warnings.append(f"{outlier_count} valeur(s) aberrante(s) potentielle(s)")
+
+    return ValidationResult(errors=errors, warnings=warnings, cleaned=cleaned)
+
+
+def resolve_duplicates(df: pd.DataFrame, strategy: str) -> pd.DataFrame:
+    data = df.copy()
+    if data.empty:
+        return data
+
+    if strategy == "garder_la_derniere":
+        return data.sort_values("Date").drop_duplicates(subset=["Date"], keep="last")
+    numeric_cols = data.select_dtypes(include=["number"]).columns.tolist()
+    agg = "mean" if strategy == "moyenne_journaliere" else "median"
+    grouped_num = data.groupby("Date", as_index=False)[numeric_cols].agg(agg)
+    others = data.sort_values("Date").drop_duplicates(subset=["Date"], keep="last")
+    for c in numeric_cols:
+        others[c] = grouped_num.set_index("Date")[c].reindex(others["Date"]).values
+    return others.sort_values("Date").reset_index(drop=True)
+
+
+def data_quality_report(df: pd.DataFrame) -> dict[str, Any]:
+    if df.empty:
+        return {
+            "score": 0,
+            "duplicates": 0,
+            "missing_days": 0,
+            "weekly_measurements": 0.0,
+            "irregularity": 1.0,
+            "last_entry": None,
+            "anomalies": 0,
+        }
+    series = df.sort_values("Date")
+    duplicates = int(series.duplicated(subset=["Date"]).sum())
+    span = max((series["Date"].max() - series["Date"].min()).days, 1)
+    expected_days = span + 1
+    unique_days = int(series["Date"].nunique())
+    missing_days = max(expected_days - unique_days, 0)
+    weekly = unique_days / max(span / 7, 1)
+    deltas = series["Date"].diff().dt.days.dropna()
+    irregularity = float(deltas.std() / (deltas.mean() + 1e-9)) if not deltas.empty else 1.0
+    mad = np.median(np.abs(series["Poids (Kgs)"] - series["Poids (Kgs)"].median())) + 1e-9
+    robust_z = np.abs((series["Poids (Kgs)"] - series["Poids (Kgs)"].median()) / (1.4826 * mad))
+    anomalies = int((robust_z > 3.5).sum())
+
+    penalties = duplicates * 2 + missing_days * 0.1 + anomalies * 2 + irregularity * 10
+    score = int(max(0, min(100, 100 - penalties)))
+    return {
+        "score": score,
+        "duplicates": duplicates,
+        "missing_days": missing_days,
+        "weekly_measurements": round(float(weekly), 2),
+        "irregularity": round(irregularity, 3),
+        "last_entry": series["Date"].max(),
+        "anomalies": anomalies,
+    }

--- a/app/core/evaluation.py
+++ b/app/core/evaluation.py
@@ -1,0 +1,67 @@
+"""Évaluation robuste des prévisions (walk-forward)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import mean_absolute_error, mean_squared_error
+from sklearn.model_selection import TimeSeriesSplit
+
+
+def smape(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    denom = np.abs(y_true) + np.abs(y_pred)
+    return float(np.mean(np.where(denom == 0, 0, 2 * np.abs(y_pred - y_true) / denom)) * 100)
+
+
+def directional_accuracy(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    if len(y_true) < 2:
+        return 0.0
+    return float((np.sign(np.diff(y_true)) == np.sign(np.diff(y_pred))).mean() * 100)
+
+
+def compute_metrics(y_true: np.ndarray, y_pred: np.ndarray) -> dict[str, float]:
+    rmse = float(np.sqrt(mean_squared_error(y_true, y_pred)))
+    mape = float(np.mean(np.abs((y_true - y_pred) / np.where(y_true == 0, 1e-9, y_true))) * 100)
+    return {
+        "mae": float(mean_absolute_error(y_true, y_pred)),
+        "rmse": rmse,
+        "mape": mape,
+        "smape": smape(y_true, y_pred),
+        "biais": float(np.mean(y_pred - y_true)),
+        "directional_accuracy": directional_accuracy(y_true, y_pred),
+    }
+
+
+def baseline_predictions(train: pd.Series, test_len: int, kind: str) -> np.ndarray:
+    if kind == "last":
+        return np.repeat(train.iloc[-1], test_len)
+    if kind == "ma7":
+        return np.repeat(train.tail(7).mean(), test_len)
+    if kind == "ma14":
+        return np.repeat(train.tail(14).mean(), test_len)
+    slope = (train.iloc[-1] - train.iloc[0]) / max(len(train) - 1, 1)
+    return np.array([train.iloc[-1] + slope * (i + 1) for i in range(test_len)])
+
+
+def walk_forward_backtest(series: pd.Series, model_fn, n_splits: int = 5) -> dict[str, float]:
+    if len(series) < 8:
+        return {"mae": np.nan, "rmse": np.nan, "mape": np.nan, "smape": np.nan, "biais": np.nan, "directional_accuracy": np.nan}
+
+    splitter = TimeSeriesSplit(n_splits=min(n_splits, max(2, len(series) // 5)))
+    y_true_all, y_pred_all = [], []
+    for train_idx, test_idx in splitter.split(series):
+        train = series.iloc[train_idx]
+        test = series.iloc[test_idx]
+        pred = model_fn(train, len(test))
+        y_true_all.extend(test.values)
+        y_pred_all.extend(pred)
+    return compute_metrics(np.asarray(y_true_all), np.asarray(y_pred_all))
+
+
+def evaluate_baselines(series: pd.Series) -> pd.DataFrame:
+    rows = []
+    mapping = {"last": "Dernière valeur", "ma7": "Moyenne mobile 7j", "ma14": "Moyenne mobile 14j", "drift": "Tendance linéaire"}
+    for key, label in mapping.items():
+        metrics = walk_forward_backtest(series, lambda tr, h, k=key: baseline_predictions(tr, h, k))
+        rows.append({"modèle": label, **metrics})
+    return pd.DataFrame(rows)

--- a/app/core/features.py
+++ b/app/core/features.py
@@ -1,0 +1,29 @@
+"""Feature engineering pour les modèles temporels."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def build_features(df: pd.DataFrame, height_m: float | None = None) -> pd.DataFrame:
+    data = df.sort_values("Date").copy()
+    data["jour_semaine"] = data["Date"].dt.weekday
+    data["jours_depuis_derniere_mesure"] = data["Date"].diff().dt.days.fillna(0)
+    data["variation_journaliere"] = data["Poids (Kgs)"].diff().fillna(0)
+
+    for lag in (1, 3, 7, 14, 30):
+        data[f"lag_{lag}"] = data["Poids (Kgs)"].shift(lag)
+
+    for w in (7, 14, 30):
+        data[f"roll_mean_{w}"] = data["Poids (Kgs)"].rolling(w, min_periods=1).mean()
+        data[f"roll_std_{w}"] = data["Poids (Kgs)"].rolling(w, min_periods=2).std().fillna(0)
+
+    if height_m and height_m > 0:
+        data["imc"] = data["Poids (Kgs)"] / (height_m**2)
+
+    if {"Calories consommées", "Calories brûlées"}.issubset(data.columns):
+        data["bilan_calorique"] = (
+            pd.to_numeric(data["Calories consommées"], errors="coerce").fillna(0)
+            - pd.to_numeric(data["Calories brûlées"], errors="coerce").fillna(0)
+        )
+    return data

--- a/app/core/forecasting.py
+++ b/app/core/forecasting.py
@@ -1,0 +1,60 @@
+"""Prévisions multi-modèles avec intervalles de confiance."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from statsmodels.tsa.statespace.sarimax import SARIMAX
+
+from app.core.features import build_features
+from app.core.models import get_quantile_models, get_regression_models
+
+
+def _training_matrix(df: pd.DataFrame, height_m: float) -> tuple[pd.DataFrame, pd.Series]:
+    feat = build_features(df, height_m=height_m).dropna().copy()
+    X = feat.drop(columns=["Date", "Poids (Kgs)", "Notes", "Condition de mesure"], errors="ignore")
+    y = feat["Poids (Kgs)"]
+    return X, y
+
+
+def forecast_with_ml(df: pd.DataFrame, horizon: int, height_m: float) -> pd.DataFrame:
+    if len(df) < 20:
+        return pd.DataFrame()
+    X, y = _training_matrix(df, height_m)
+    if len(X) < 10:
+        return pd.DataFrame()
+
+    models = get_quantile_models()
+    for m in models.values():
+        m.fit(X, y)
+
+    future_dates = pd.date_range(df["Date"].max() + pd.Timedelta(days=1), periods=horizon, freq="D")
+    last_row = df.iloc[-1:].copy()
+    rows = []
+    for d in future_dates:
+        row = last_row.copy()
+        row.loc[row.index[0], "Date"] = d
+        feat = build_features(pd.concat([df, pd.DataFrame(rows + [row.iloc[0]])], ignore_index=True), height_m=height_m).tail(1)
+        Xf = feat.drop(columns=["Date", "Poids (Kgs)", "Notes", "Condition de mesure"], errors="ignore")
+        p10 = float(models["q10"].predict(Xf)[0])
+        p50 = float(models["q50"].predict(Xf)[0])
+        p90 = float(models["q90"].predict(Xf)[0])
+        rows.append({"Date": d, "prevision": p50, "borne_basse": p10, "borne_haute": p90, "confiance": 0.8})
+    return pd.DataFrame(rows)
+
+
+def forecast_with_sarimax(df: pd.DataFrame, horizon: int) -> pd.DataFrame:
+    if len(df) < 14:
+        return pd.DataFrame()
+    model = SARIMAX(df["Poids (Kgs)"], order=(1, 1, 1), seasonal_order=(1, 0, 1, 7), enforce_stationarity=False, enforce_invertibility=False)
+    fitted = model.fit(disp=False)
+    pred = fitted.get_forecast(steps=horizon)
+    ci = pred.conf_int(alpha=0.1)
+    dates = pd.date_range(df["Date"].max() + pd.Timedelta(days=1), periods=horizon, freq="D")
+    return pd.DataFrame({
+        "Date": dates,
+        "prevision": pred.predicted_mean.values,
+        "borne_basse": ci.iloc[:, 0].values,
+        "borne_haute": ci.iloc[:, 1].values,
+        "confiance": 0.9,
+    })

--- a/app/core/insights.py
+++ b/app/core/insights.py
@@ -1,0 +1,67 @@
+"""Insights analytiques: plateau, anomalies, ETA objectif."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import IsolationForest
+
+
+def detect_plateau(df: pd.DataFrame, window: int = 14) -> dict[str, float | str]:
+    if len(df) < window:
+        return {"status": "données insuffisantes", "slope": 0.0, "volatility": 0.0}
+    recent = df.sort_values("Date").tail(window)
+    x = np.arange(len(recent))
+    slope = float(np.polyfit(x, recent["Poids (Kgs)"], 1)[0])
+    vol = float(recent["Poids (Kgs)"].std())
+    if abs(slope) < 0.03 and vol < 0.5:
+        status = "plateau probable"
+    elif slope <= -0.03:
+        status = "baisse active"
+    elif slope >= 0.03:
+        status = "reprise de poids probable"
+    else:
+        status = "signal mixte"
+    return {"status": status, "slope": slope, "volatility": vol}
+
+
+def detect_anomalies_robust(df: pd.DataFrame, use_iforest: bool = False) -> pd.DataFrame:
+    out = df.copy()
+    if out.empty:
+        out["anomalie"] = False
+        out["raison"] = "aucune donnée"
+        return out
+    median = out["Poids (Kgs)"].median()
+    mad = np.median(np.abs(out["Poids (Kgs)"] - median)) + 1e-9
+    z = 0.6745 * (out["Poids (Kgs)"] - median) / mad
+    out["z_robuste"] = z
+    out["anomalie"] = np.abs(z) > 3.5
+    out["raison"] = np.where(out["anomalie"], "z-score robuste > 3.5", "normal")
+
+    if use_iforest and len(out) >= 10:
+        iso = IsolationForest(contamination=0.1, random_state=42)
+        out["iforest"] = iso.fit_predict(out[["Poids (Kgs)"]]) == -1
+        out["anomalie"] = out["anomalie"] | out["iforest"]
+        out.loc[out["iforest"], "raison"] = "IsolationForest"
+    out["decision"] = "à revoir"
+    return out
+
+
+def estimate_target_eta(df: pd.DataFrame, target_weight: float) -> dict[str, object]:
+    if len(df) < 7:
+        return {"credible": False, "message": "Données insuffisantes"}
+    recent = df.sort_values("Date").tail(30)
+    x = np.arange(len(recent))
+    slope, intercept = np.polyfit(x, recent["Poids (Kgs)"], 1)
+    if slope >= -0.01:
+        return {"credible": False, "message": "La tendance actuelle ne permet pas d'estimation crédible"}
+    days = int((target_weight - intercept) / slope)
+    start = recent["Date"].iloc[0]
+    eta = start + pd.Timedelta(days=max(days, 0))
+    return {
+        "credible": True,
+        "eta": eta,
+        "eta_min": eta - pd.Timedelta(days=14),
+        "eta_max": eta + pd.Timedelta(days=21),
+        "confidence": 0.6,
+    }

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -1,0 +1,24 @@
+"""Définition des modèles sklearn utilisés en prévision."""
+
+from __future__ import annotations
+
+from sklearn.ensemble import GradientBoostingRegressor, RandomForestRegressor
+from sklearn.linear_model import ElasticNet, LinearRegression, QuantileRegressor, Ridge
+
+
+def get_regression_models() -> dict[str, object]:
+    return {
+        "linear": LinearRegression(),
+        "ridge": Ridge(alpha=1.0, random_state=42),
+        "elasticnet": ElasticNet(alpha=0.01, l1_ratio=0.5, random_state=42),
+        "random_forest": RandomForestRegressor(n_estimators=200, random_state=42),
+        "boosting": GradientBoostingRegressor(random_state=42),
+    }
+
+
+def get_quantile_models() -> dict[str, QuantileRegressor]:
+    return {
+        "q10": QuantileRegressor(quantile=0.1, alpha=0),
+        "q50": QuantileRegressor(quantile=0.5, alpha=0),
+        "q90": QuantileRegressor(quantile=0.9, alpha=0),
+    }

--- a/app/pages/Dashboard.py
+++ b/app/pages/Dashboard.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+from app.core.data import data_quality_report
+from app.core.insights import detect_plateau
+from app.ui.components import alert_banner, confidence_badge, empty_state, help_box, kpi_card
+
+
+def _df() -> pd.DataFrame:
+    return st.session_state.get("filtered_data", pd.DataFrame(columns=["Date", "Poids (Kgs)"]))
+
+
+def main() -> None:
+    st.title("Dashboard")
+    df = _df()
+    if df.empty:
+        empty_state("Aucune donnée disponible. Utilisez Journal ou import CSV.")
+        return
+
+    df = df.sort_values("Date")
+    current = df["Poids (Kgs)"].iloc[-1]
+    prev = df["Poids (Kgs)"].iloc[-2] if len(df) > 1 else current
+    short = df["Poids (Kgs)"].tail(7).mean()
+    long = df["Poids (Kgs)"].tail(30).mean() if len(df) >= 30 else df["Poids (Kgs)"].mean()
+
+    c1, c2, c3, c4 = st.columns(4)
+    with c1:
+        kpi_card("Poids actuel", f"{current:.2f} kg", f"{current-prev:+.2f}")
+    with c2:
+        kpi_card("Tendance 7j", f"{short:.2f} kg")
+    with c3:
+        kpi_card("Tendance longue", f"{long:.2f} kg")
+    with c4:
+        quality = data_quality_report(df)
+        kpi_card("Qualité des données", f"{quality['score']}/100")
+
+    plateau = detect_plateau(df, window=14)
+    if plateau["status"] == "plateau probable":
+        alert_banner("Plateau probable détecté sur 14 jours.", "warning")
+
+    confidence = "élevée" if quality["score"] > 80 else "moyenne" if quality["score"] > 60 else "faible"
+    confidence_badge("Confiance signal", confidence)
+
+    fig = px.line(df, x="Date", y="Poids (Kgs)", title="Évolution du poids")
+    st.plotly_chart(fig, use_container_width=True)
+
+    help_box("Résumé hebdo", "Cette vue est analytique et informative; elle ne remplace pas un avis médical.")
+
+
+main()

--- a/app/pages/Insights.py
+++ b/app/pages/Insights.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+from app.core.data import data_quality_report
+from app.core.insights import detect_anomalies_robust, detect_plateau
+from app.ui.components import empty_state
+
+
+def _df() -> pd.DataFrame:
+    return st.session_state.get("filtered_data", pd.DataFrame(columns=["Date", "Poids (Kgs)"]))
+
+
+def main() -> None:
+    st.title("Insights / Analyse")
+    df = _df()
+    if df.empty:
+        empty_state("Pas encore de données à analyser.")
+        return
+
+    quality = data_quality_report(df)
+    st.json(quality)
+
+    plateau14 = detect_plateau(df, 14)
+    plateau30 = detect_plateau(df, 30)
+    st.write(f"14j: **{plateau14['status']}** | pente={plateau14['slope']:.3f}")
+    st.write(f"30j: **{plateau30['status']}** | pente={plateau30['slope']:.3f}")
+
+    anomalies = detect_anomalies_robust(df, use_iforest=st.toggle("Activer IsolationForest", value=False))
+    st.dataframe(anomalies[["Date", "Poids (Kgs)", "anomalie", "raison", "decision"]], use_container_width=True)
+
+
+main()

--- a/app/pages/Journal.py
+++ b/app/pages/Journal.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+from app.config import ALL_COLUMNS
+from app.core.data import validate_journal
+from app.ui.components import alert_banner, empty_state
+
+
+def _ensure_df() -> pd.DataFrame:
+    if "raw_data" not in st.session_state:
+        st.session_state["raw_data"] = pd.DataFrame(columns=ALL_COLUMNS)
+    return st.session_state["raw_data"].copy()
+
+
+def main() -> None:
+    st.title("Journal")
+    df = _ensure_df()
+    if df.empty:
+        empty_state("Commencez par ajouter une première ligne.")
+
+    edited = st.data_editor(df, num_rows="dynamic", use_container_width=True, key="journal_editor")
+    report = validate_journal(edited)
+
+    for err in report.errors:
+        alert_banner(err, "error")
+    for w in report.warnings:
+        alert_banner(w, "warning")
+
+    c1, c2 = st.columns(2)
+    with c1:
+        if st.button("Enregistrer dans la session", type="primary"):
+            st.session_state["raw_data"] = report.cleaned.copy()
+            st.session_state["filtered_data"] = report.cleaned.copy()
+            st.success("Journal enregistré en session.")
+    with c2:
+        st.download_button(
+            "Exporter CSV",
+            data=report.cleaned.to_csv(index=False).encode("utf-8"),
+            file_name="journal_poids.csv",
+            mime="text/csv",
+        )
+
+
+main()

--- a/app/pages/Predictions.py
+++ b/app/pages/Predictions.py
@@ -1,336 +1,60 @@
-
-"""Prédictions page focusing on forecasting and time-series analysis."""
-
 from __future__ import annotations
 
-import numpy as np
 import pandas as pd
-import plotly.express as px
 import plotly.graph_objects as go
 import streamlit as st
-from pmdarima import auto_arima
-from sklearn.linear_model import LinearRegression
-from sklearn.model_selection import TimeSeriesSplit, cross_val_score
-from sklearn.utils import resample
-from statsmodels.tsa.seasonal import STL
-from statsmodels.tsa.statespace.sarimax import SARIMAX
-from statsmodels.tsa.stattools import acf, pacf
+
+from app.core.evaluation import evaluate_baselines
+from app.core.forecasting import forecast_with_ml, forecast_with_sarimax
+from app.core.insights import estimate_target_eta
+from app.ui.components import alert_banner, empty_state
 
 
-
-from app.utils import apply_theme, load_data
-from app.deploy import show_deployment_info
-
-# Debug: show page path only if debug_mode is enabled
-if st.secrets.get("debug_mode", False):
-    st.caption(f"PAGE={__file__}")
-def _get_data():
-    df = st.session_state.get("filtered_data")
-    if df is None:
-        df = load_data()
-        st.session_state["filtered_data"] = df
-        st.session_state["raw_data"] = df
-    return df.copy()
+def _df() -> pd.DataFrame:
+    return st.session_state.get("filtered_data", pd.DataFrame(columns=["Date", "Poids (Kgs)"]))
 
 
-def render_linear_regression(df):
-    st.header("Régression Linéaire et Intervalles de Confiance")
-    if df.empty or len(df) < 3:
-        st.warning("Données insuffisantes pour faire des prévisions (minimum 3 entrées).")
+@st.fragment
+def _heavy_predictions(df: pd.DataFrame, horizon: int, height_m: float) -> None:
+    sarimax = forecast_with_sarimax(df, horizon=horizon)
+    quantile = forecast_with_ml(df, horizon=horizon, height_m=height_m)
+
+    if sarimax.empty and quantile.empty:
+        alert_banner("Données insuffisantes pour calculer des prévisions fiables.", "warning")
         return
 
-    df = df.copy()
-    df["Date_numeric"] = (df["Date"] - df["Date"].min()) / np.timedelta64(1, "D")
-    X = df[["Date_numeric"]]
-    y = df["Poids (Kgs)"]
-
-    n_splits = min(5, len(df) - 1)
-    try:
-        tscv = TimeSeriesSplit(n_splits=n_splits)
-        lin_scores = cross_val_score(
-            LinearRegression(),
-            X,
-            y,
-            scoring="neg_mean_squared_error",
-            cv=tscv,
-        )
-        st.write(f"MSE moyen (Régression Linéaire) : **{-lin_scores.mean():.2f}**")
-    except ValueError as error:
-        st.warning(f"Validation croisée impossible avec les données actuelles : {error}")
-        lin_scores = None
-
-    reg = LinearRegression().fit(X, y)
-    predictions = reg.predict(X)
-
-    n_bootstraps = 500
-    boot_preds = np.zeros((n_bootstraps, len(X)))
-    for i in range(n_bootstraps):
-        X_boot, y_boot = resample(X, y)
-        reg_boot = LinearRegression().fit(X_boot, y_boot)
-        boot_preds[i] = reg_boot.predict(X)
-    pred_lower = np.percentile(boot_preds, 2.5, axis=0)
-    pred_upper = np.percentile(boot_preds, 97.5, axis=0)
-
-    theme = st.session_state.get("theme", "Default")
-    fig_reg = px.scatter(
-        df,
-        x="Date",
-        y="Poids (Kgs)",
-        title="Régression Linéaire avec IC",
-        labels={"Poids (Kgs)": "Poids (en Kgs)"},
-    )
-    fig_reg.add_trace(
-        go.Scatter(
-            x=df["Date"],
-            y=predictions,
-            mode="lines",
-            name="Prévisions",
-            line=dict(color="blue"),
-        )
-    )
-    fig_reg.add_trace(
-        go.Scatter(
-            x=df["Date"],
-            y=pred_lower,
-            mode="lines",
-            line_color="lightblue",
-            name="IC Inférieur",
-        )
-    )
-    fig_reg.add_trace(
-        go.Scatter(
-            x=df["Date"],
-            y=pred_upper,
-            mode="lines",
-            line_color="lightblue",
-            fill="tonexty",
-            name="IC Supérieur",
-        )
-    )
-    fig_reg = apply_theme(fig_reg, theme)
-    st.plotly_chart(fig_reg, use_container_width=True)
-    
-    # MID-AI-1: Model Confidence Metrics
-    from sklearn.metrics import r2_score, mean_absolute_error, mean_squared_error
-    r2 = r2_score(y, predictions)
-    mae = mean_absolute_error(y, predictions)
-    rmse = np.sqrt(mean_squared_error(y, predictions))
-    
-    st.subheader("📊 Métriques de Confiance du Modèle")
-    mcol1, mcol2, mcol3, mcol4 = st.columns(4)
-    with mcol1:
-        st.metric("R²", f"{r2:.3f}", help="Coefficient de détermination (1.0 = parfait)")
-    with mcol2:
-        st.metric("MAE", f"{mae:.2f} kg", help="Erreur absolue moyenne")
-    with mcol3:
-        st.metric("RMSE", f"{rmse:.2f} kg", help="Racine de l'erreur quadratique moyenne")
-    with mcol4:
-        # Confidence level based on R²
-        if r2 >= 0.8:
-            confidence = "🟢 Haute"
-            conf_help = "R² ≥ 0.8 : Le modèle explique bien les données"
-        elif r2 >= 0.5:
-            confidence = "🟡 Moyenne"
-            conf_help = "0.5 ≤ R² < 0.8 : Précision modérée"
-        else:
-            confidence = "🔴 Faible"
-            conf_help = "R² < 0.5 : Prédictions peu fiables"
-        st.metric("Confiance", confidence, help=conf_help)
-    
-    # Width of confidence interval as percentage
-    ic_width = (pred_upper - pred_lower).mean()
-    st.caption(f"Largeur moyenne de l'intervalle de confiance : ±{ic_width/2:.2f} kg")
-
-    target_weight = st.session_state.get("target_weights", (95.0, 90.0, 85.0, 80.0))[-1]
-    try:
-        if reg.coef_[0] >= 0:
-            st.error("Le modèle n’indique pas une perte de poids. Impossible d’estimer la date d’atteinte de l’objectif.")
-        else:
-            days_to_target = (target_weight - reg.intercept_) / reg.coef_[0]
-            target_date = df["Date"].min() + pd.to_timedelta(days_to_target, unit="D")
-            if target_date < df["Date"].max():
-                st.warning("L'objectif a déjà été atteint selon les prévisions.")
-            else:
-                st.write(f"**Date estimée** pour atteindre {target_weight} Kgs : {target_date.date()}")
-    except Exception as error:
-        st.error(f"Erreur dans le calcul de la date estimée : {error}")
-
-    future_days = st.slider("Nombre de jours à prédire", 1, 365, 30)
-    future_dates = pd.date_range(start=df["Date"].max() + pd.Timedelta(days=1), periods=future_days)
-    future_numeric = (future_dates - df["Date"].min()) / np.timedelta64(1, "D")
-    future_predictions = reg.predict(future_numeric.values.reshape(-1, 1))
-    future_df = pd.DataFrame({"Date": future_dates, "Prévisions": future_predictions})
-    fig_future = px.line(future_df, x="Date", y="Prévisions", title="Prévisions Futures")
-    fig_future = apply_theme(fig_future, theme)
-    st.plotly_chart(fig_future, use_container_width=True)
-
-    df["Poids_diff"] = df["Poids (Kgs)"].diff()
-    mean_change_rate = df["Poids_diff"].mean()
-    st.write(f"Taux de changement moyen du poids : **{mean_change_rate:.2f} Kgs/jour**")
-    coef_var = df["Poids (Kgs)"].std() / df["Poids (Kgs)"].mean()
-    st.write(f"Coefficient de variation du poids : **{coef_var * 100:.2f}%**")
+    fig = go.Figure()
+    fig.add_scatter(x=df["Date"], y=df["Poids (Kgs)"], name="Historique")
+    for name, pred in [("SARIMAX", sarimax), ("Quantile", quantile)]:
+        if pred.empty:
+            continue
+        fig.add_scatter(x=pred["Date"], y=pred["prevision"], name=f"Prévision {name}")
+        fig.add_scatter(x=pred["Date"], y=pred["borne_basse"], name=f"Borne basse {name}", line=dict(dash="dot"))
+        fig.add_scatter(x=pred["Date"], y=pred["borne_haute"], name=f"Borne haute {name}", line=dict(dash="dot"))
+    st.plotly_chart(fig, use_container_width=True)
 
 
-def render_stl_and_sarima(df):
-    st.header("Analyse STL et SARIMA")
+def main() -> None:
+    st.title("Prévisions")
+    df = _df()
     if df.empty:
-        st.warning("Aucune donnée pour l’analyse.")
+        empty_state("Ajoutez des mesures dans Journal pour lancer les prévisions.")
         return
 
-    period = 7
-    if len(df) < period * 2:
-        st.warning("Au moins 14 enregistrements sont nécessaires pour l'analyse STL/SARIMA.")
-        return
+    horizon = st.slider("Horizon (jours)", 7, 90, 30)
+    baseline_df = evaluate_baselines(df["Poids (Kgs)"])
+    st.subheader("Leaderboard baselines (backtest walk-forward)")
+    st.dataframe(baseline_df.sort_values("mae"), use_container_width=True)
 
-    theme = st.session_state.get("theme", "Default")
-    df = df.copy()
+    _heavy_predictions(df, horizon=horizon, height_m=st.session_state.get("height_m", 1.82))
 
-    st.subheader("Analyse STL (Tendance et Saisonnalité)")
-    try:
-        stl = STL(df.set_index("Date")["Poids (Kgs)"], period=period)
-        res = stl.fit()
-    except ValueError as error:
-        st.warning(f"Impossible de réaliser la décomposition STL : {error}")
-        return
-    df["Trend"] = res.trend.values
-    df["Seasonal"] = res.seasonal.values
-    df["Resid"] = res.resid.values
-
-    col1, col2, col3 = st.columns(3)
-    with col1:
-        fig_trend = px.line(df, x="Date", y="Trend", title="Tendance")
-        fig_trend = apply_theme(fig_trend, theme)
-        st.plotly_chart(fig_trend, use_container_width=True)
-    with col2:
-        fig_seasonal = px.line(df, x="Date", y="Seasonal", title="Saisonnalité")
-        fig_seasonal = apply_theme(fig_seasonal, theme)
-        st.plotly_chart(fig_seasonal, use_container_width=True)
-    with col3:
-        fig_resid = px.line(df, x="Date", y="Resid", title="Résidus")
-        fig_resid = apply_theme(fig_resid, theme)
-        st.plotly_chart(fig_resid, use_container_width=True)
-
-    st.subheader("Prédictions SARIMA")
-    try:
-        with st.spinner("🔄 Calcul du modèle SARIMA en cours..."):
-            sarima_model = SARIMAX(df["Poids (Kgs)"], order=(1, 1, 1), seasonal_order=(1, 1, 1, period))
-            sarima_results = sarima_model.fit(disp=False)
-            df["SARIMA_Predictions"] = sarima_results.predict(start=0, end=len(df) - 1, dynamic=False)
-        fig_sarima = px.scatter(df, x="Date", y="Poids (Kgs)", title="SARIMA")
-        fig_sarima.add_trace(
-            go.Scatter(
-                x=df["Date"],
-                y=df["SARIMA_Predictions"],
-                mode="lines",
-                name="Prévisions SARIMA",
-            )
-        )
-        fig_sarima = apply_theme(fig_sarima, theme)
-        st.plotly_chart(fig_sarima, use_container_width=True)
-    except Exception as error:  # statsmodels peut lever plusieurs types d'exceptions
-        st.warning(f"Le modèle SARIMA n'a pas pu converger : {error}")
-
-    st.subheader("Variabilité et Corrélations Temporelles")
-    max_window = min(30, len(df))
-    if max_window < 3:
-        st.warning("Données insuffisantes pour calculer un écart type mobile.")
-        return
-    std_window = st.slider(
-        "Fenêtre pour l'écart type mobile",
-        min_value=3,
-        max_value=max_window,
-        value=min(7, max_window),
-        key="std_window",
-    )
-    df["Rolling_STD"] = df["Poids (Kgs)"].rolling(window=std_window).std()
-    fig_std = px.line(df, x="Date", y="Rolling_STD", title="Écart Type Mobile")
-    fig_std = apply_theme(fig_std, theme)
-    st.plotly_chart(fig_std, use_container_width=True)
-
-    max_lag = min(30, len(df) - 1)
-    if max_lag < 1:
-        st.warning("Pas assez d'observations pour calculer l'ACF/PACF.")
-        return
-    lag = st.slider(
-        "Nombre de décalages pour l'ACF/PACF",
-        min_value=1,
-        max_value=max_lag,
-        value=min(7, max_lag),
-        key="acf_lag",
-    )
-    try:
-        acf_vals = acf(df["Poids (Kgs)"], nlags=lag, missing="drop")
-        pacf_vals = pacf(df["Poids (Kgs)"], nlags=lag, method="ywm")
-    except ValueError as error:
-        st.warning(f"Impossible de calculer l'ACF/PACF : {error}")
-        return
-    fig_acf = px.bar(x=list(range(len(acf_vals))), y=acf_vals, title="Autocorrélation (ACF)")
-    fig_pacf = px.bar(x=list(range(len(pacf_vals))), y=pacf_vals, title="Autocorrélation Partielle (PACF)")
-    fig_acf = apply_theme(fig_acf, theme)
-    fig_pacf = apply_theme(fig_pacf, theme)
-    st.plotly_chart(fig_acf, use_container_width=True)
-    st.plotly_chart(fig_pacf, use_container_width=True)
+    eta = estimate_target_eta(df, st.session_state.get("target_weight", 80.0))
+    st.subheader("Estimation de date objectif")
+    if eta.get("credible"):
+        st.write(f"Date cible estimée : **{eta['eta'].date()}**")
+        st.caption(f"Plage plausible: {eta['eta_min'].date()} → {eta['eta_max'].date()} | Confiance {eta['confidence']:.0%}")
+    else:
+        alert_banner(str(eta.get("message", "Estimation indisponible")), "warning")
 
 
-def render_auto_arima(df):
-    st.header("Prévisions Auto-ARIMA")
-    if df.empty:
-        st.warning("Aucune donnée pour générer des prévisions Auto-ARIMA.")
-        return
-
-    if len(df) < 10:
-        st.warning("Au moins 10 enregistrements sont nécessaires pour entraîner Auto-ARIMA.")
-        return
-
-    theme = st.session_state.get("theme", "Default")
-    future_arima_days = st.slider(
-        "Jours à prédire",
-        min_value=1,
-        max_value=60,
-        value=30,
-        key="arima_days",
-    )
-    try:
-        with st.spinner("🔄 Calcul Auto-ARIMA en cours (peut prendre quelques secondes)..."):
-            arima_model = auto_arima(
-                df["Poids (Kgs)"],
-                seasonal=True,
-                m=7,
-                suppress_warnings=True,
-            )
-            arima_forecast = arima_model.predict(n_periods=future_arima_days)
-    except Exception as error:  # pmdarima renvoie divers types d'erreurs
-        st.warning(f"Le modèle Auto-ARIMA n'a pas pu être ajusté : {error}")
-        return
-
-    arima_dates = pd.date_range(
-        start=df["Date"].max() + pd.Timedelta(days=1),
-        periods=future_arima_days,
-    )
-    fig_arima = px.line(
-        x=arima_dates,
-        y=arima_forecast,
-        labels={"x": "Date", "y": "Prévision (Kgs)"},
-        title="Prévisions Auto-ARIMA",
-    )
-    fig_arima.add_scatter(
-        x=df["Date"],
-        y=df["Poids (Kgs)"],
-        mode="lines",
-        name="Historique",
-    )
-    fig_arima = apply_theme(fig_arima, theme)
-    st.plotly_chart(fig_arima, use_container_width=True)
-
-
-def main():
-    df = _get_data()
-    render_linear_regression(df)
-    render_stl_and_sarima(df)
-    render_auto_arima(df)
-
-
-if __name__ == "__main__":
-    main()
 main()
-show_deployment_info()

--- a/app/pages/Settings.py
+++ b/app/pages/Settings.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from app.config import AppDefaults, DUPLICATE_STRATEGIES
+
+
+def main() -> None:
+    st.title("Paramètres / Qualité")
+    defaults = AppDefaults()
+    with st.form("settings_form"):
+        target = st.number_input("Poids objectif (kg)", value=float(st.session_state.get("target_weight", defaults.target_weight)))
+        height_cm = st.number_input("Taille (cm)", value=float(st.session_state.get("height_cm", defaults.height_cm)))
+        duplicate = st.selectbox("Gestion doublons journaliers", DUPLICATE_STRATEGIES, index=DUPLICATE_STRATEGIES.index(st.session_state.get("duplicate_strategy", defaults.duplicate_strategy)))
+        default_model = st.selectbox("Modèle par défaut", ["ridge", "elasticnet", "random_forest", "boosting"], index=0)
+        submitted = st.form_submit_button("Enregistrer")
+
+    if submitted:
+        st.session_state["target_weight"] = float(target)
+        st.session_state["height_cm"] = float(height_cm)
+        st.session_state["height_m"] = float(height_cm) / 100
+        st.session_state["duplicate_strategy"] = duplicate
+        st.session_state["default_model"] = default_model
+        st.success("Paramètres enregistrés.")
+
+    st.caption("Diagnostic système")
+    st.write({"streamlit": st.__version__, "session_keys": sorted(list(st.session_state.keys()))[:10]})
+
+
+main()

--- a/app/ui/components.py
+++ b/app/ui/components.py
@@ -1,0 +1,27 @@
+"""Composants UI réutilisables Streamlit."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+
+def kpi_card(title: str, value: str, delta: str | None = None, help_text: str | None = None) -> None:
+    st.metric(label=title, value=value, delta=delta, help=help_text)
+
+
+def confidence_badge(label: str, level: str) -> None:
+    color = {"élevée": "🟢", "moyenne": "🟡", "faible": "🔴"}.get(level, "⚪")
+    st.caption(f"{color} **{label}** : {level.title()}")
+
+
+def alert_banner(message: str, kind: str = "info") -> None:
+    getattr(st, kind if kind in {"info", "warning", "error", "success"} else "info")(message)
+
+
+def empty_state(message: str) -> None:
+    st.info(f"📭 {message}")
+
+
+def help_box(title: str, text: str) -> None:
+    with st.expander(f"ℹ️ {title}", expanded=False):
+        st.write(text)

--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -1,0 +1,18 @@
+"""Thème visuel léger pour Suivi V2."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+
+def apply_global_theme() -> None:
+    st.markdown(
+        """
+        <style>
+        .block-container {padding-top: 1rem;}
+        h1, h2, h3 {letter-spacing: 0.2px;}
+        div[data-testid="stMetric"] {background:#f7f9fc;border-radius:12px;padding:10px;}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )

--- a/docs/MODEL_CARD.md
+++ b/docs/MODEL_CARD.md
@@ -1,98 +1,22 @@
-# Model Card – Suivi_V1 Predictions
+# MODEL_CARD — Suivi V2
 
-## Modèles Utilisés
+## Modèles utilisés
+- Baselines: dernière valeur, MA7, MA14, drift.
+- Régression: LinearRegression, Ridge, ElasticNet.
+- Non-linéaires: RandomForestRegressor, GradientBoostingRegressor.
+- Série temporelle: SARIMAX.
+- Intervalles: QuantileRegressor (q10/q50/q90) et IC SARIMAX.
 
-### 1. Régression Linéaire
-- **Type** : Régression simple sur données temporelles
-- **Features** : Date numérique (jours depuis début)
-- **Cible** : Poids (Kgs)
-- **Usage** : Estimation de la tendance générale et date d'atteinte objectif
+## Évaluation
+- Validation: walk-forward / expanding window (`TimeSeriesSplit`).
+- Métriques: MAE, RMSE, MAPE, sMAPE, biais moyen, directional accuracy.
+- Affichage distinct backtest vs métriques d'ajustement local.
 
-### 2. Random Forest
-- **Type** : Ensemble de 100 arbres de décision
-- **Features** : Date numérique
-- **Cible** : Poids (Kgs)
-- **Usage** : Comparaison de modèle, robustesse aux outliers
+## Fiabilité / limites
+- Les prévisions ne sont pas fiables avec peu de données; l'application l'indique.
+- Les sorties sont analytiques, non diagnostiques et non médicales.
+- En présence d'anomalies ou forte irrégularité, le score de confiance est abaissé.
 
-### 3. SARIMA / Auto-ARIMA
-- **Type** : Modèle de séries temporelles avec saisonnalité
-- **Paramètres SARIMA** : order=(1,1,1), seasonal_order=(1,1,1,7)
-- **Auto-ARIMA** : Sélection automatique via pmdarima, m=7 (saisonnalité hebdomadaire)
-- **Usage** : Prévisions à court/moyen terme
-
----
-
-## Métriques de Performance
-
-| Métrique | Description | Interprétation |
-|----------|-------------|----------------|
-| **R²** | Coefficient de détermination | 0.8+ = Haute confiance, 0.5-0.8 = Moyenne, <0.5 = Faible |
-| **MAE** | Erreur absolue moyenne | Erreur moyenne en kg |
-| **RMSE** | Racine erreur quadratique moyenne | Pénalise les grandes erreurs |
-| **MSE** | Erreur quadratique moyenne | Utilisé pour validation croisée |
-
-### Validation
-- **TimeSeriesSplit** : 5-fold temporel (respecte l'ordre chronologique)
-- **Bootstrap** : 500 itérations pour intervalles de confiance (95%)
-
----
-
-## Hypothèses et Limitations
-
-### Hypothèses
-1. **Linéarité** : La tendance du poids est approximativement linéaire
-2. **Saisonnalité** : Cycles hebdomadaires (7 jours)
-3. **Stationnarité** : Après différenciation, la série est stationnaire
-
-### Limitations
-| Limitation | Impact | Mitigation |
-|------------|--------|------------|
-| Peu de données (<30 points) | Prédictions peu fiables | Indicateur confiance visuel |
-| Outliers non traités | Biais des modèles | Détection anomalies séparée |
-| Pas de features externes | Manque contexte (régime, sport) | Documentation |
-| Drift non détecté automatiquement | Modèle devient obsolète | Ré-entraînement manuel |
-
-### Biais Potentiels
-- **Biais de sélection** : Données saisies manuellement (peut omettre mauvais jours)
-- **Biais temporel** : Plus de données récentes → modèle biaisé vers période récente
-
----
-
-## Guide de Ré-entraînement
-
-### Quand ré-entraîner ?
-1. Après ajout de >20% nouvelles données
-2. Si R² chute sous 0.5
-3. Après changement important de comportement (nouveau régime, etc.)
-
-### Comment ré-entraîner ?
-Les modèles sont entraînés **automatiquement** à chaque chargement de page.
-Aucune action manuelle requise.
-
-Pour forcer un ré-entraînement :
-1. Cliquer sur "Recharger les données" dans la sidebar
-2. La page recalculera tous les modèles
-
-### Monitoring Minimal
-```python
-# Vérifier les résidus
-residuals = y_true - y_pred
-if np.abs(residuals).mean() > seuil_acceptable:
-    print("⚠️ Modèle potentiellement obsolète")
-```
-
----
-
-## Confidentialité et Éthique
-
-- **Données personnelles** : Poids uniquement, pas d'identifiants
-- **Stockage** : Google Sheets (responsabilité utilisateur)
-- **Pas de partage** : Modèles locaux, pas d'envoi de données
-
----
-
-## Changelog
-| Version | Date | Modifications |
-|---------|------|---------------|
-| 1.0 | 2024-12 | Création initiale |
-| 1.1 | 2024-12 | Ajout métriques confiance (R², MAE, RMSE) |
+## Hypothèses
+- Série temporelle quotidienne avec bruit modéré.
+- Les patterns comportementaux ne sont disponibles que si colonnes optionnelles renseignées.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+@pytest.fixture
+def synthetic_df() -> pd.DataFrame:
+    rng = pd.date_range("2026-01-01", periods=60, freq="D")
+    trend = np.linspace(92, 86, 60)
+    noise = np.random.default_rng(42).normal(0, 0.25, 60)
+    return pd.DataFrame({"Date": rng, "Poids (Kgs)": trend + noise})

--- a/tests/test_core_v2.py
+++ b/tests/test_core_v2.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from app.core.data import clean_weight_dataframe, data_quality_report, validate_journal
+from app.core.evaluation import evaluate_baselines, walk_forward_backtest
+from app.core.features import build_features
+from app.core.insights import detect_anomalies_robust, detect_plateau, estimate_target_eta
+
+
+def test_clean_and_validate_columns():
+    raw = pd.DataFrame({"dates": ["01/01/2026", "bad"], "poids": ["80,2", "x"]})
+    cleaned = clean_weight_dataframe(raw)
+    assert list(cleaned.columns[:2]) == ["Date", "Poids (Kgs)"]
+    res = validate_journal(raw)
+    assert len(res.errors) == 0
+    assert len(res.cleaned) == 1
+
+
+def test_feature_engineering(synthetic_df):
+    feat = build_features(synthetic_df, height_m=1.82)
+    for col in ["lag_1", "lag_30", "roll_mean_7", "variation_journaliere", "jour_semaine", "imc"]:
+        assert col in feat.columns
+
+
+def test_backtesting_outputs(synthetic_df):
+    table = evaluate_baselines(synthetic_df["Poids (Kgs)"])
+    assert {"modèle", "mae", "rmse", "directional_accuracy"}.issubset(table.columns)
+    assert len(table) == 4
+
+
+def test_walk_forward_small_series():
+    s = pd.Series([80.0, 79.8, 79.7])
+    out = walk_forward_backtest(s, lambda tr, h: np.repeat(tr.iloc[-1], h))
+    assert np.isnan(out["mae"])
+
+
+def test_eta_objectif(synthetic_df):
+    eta = estimate_target_eta(synthetic_df, target_weight=84.0)
+    assert "credible" in eta
+
+
+def test_plateau_detection(synthetic_df):
+    res = detect_plateau(synthetic_df, window=14)
+    assert "status" in res and "slope" in res
+
+
+def test_anomalies_detection(synthetic_df):
+    df = synthetic_df.copy()
+    df.loc[df.index[-1], "Poids (Kgs)"] = 99
+    out = detect_anomalies_robust(df)
+    assert out["anomalie"].any()
+
+
+def test_data_quality_report(synthetic_df):
+    r = data_quality_report(synthetic_df)
+    assert 0 <= r["score"] <= 100

--- a/tests/test_streamlit_smoke.py
+++ b/tests/test_streamlit_smoke.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pandas as pd
+from streamlit.testing.v1 import AppTest
+
+
+def _state(at: AppTest) -> None:
+    at.session_state["filtered_data"] = pd.DataFrame({"Date": pd.date_range("2026-01-01", periods=20), "Poids (Kgs)": [90 - i * 0.1 for i in range(20)]})
+    at.session_state["raw_data"] = at.session_state["filtered_data"].copy()
+
+
+def test_dashboard_smoke():
+    at = AppTest.from_file("app/pages/Dashboard.py")
+    _state(at)
+    at.run()
+    assert not at.exception
+
+
+def test_journal_smoke():
+    at = AppTest.from_file("app/pages/Journal.py")
+    _state(at)
+    at.run()
+    assert not at.exception
+
+
+def test_predictions_smoke():
+    at = AppTest.from_file("app/pages/Predictions.py")
+    _state(at)
+    at.run()
+    assert not at.exception
+
+
+def test_insights_smoke():
+    at = AppTest.from_file("app/pages/Insights.py")
+    _state(at)
+    at.run()
+    assert not at.exception
+
+
+def test_settings_smoke():
+    at = AppTest.from_file("app/pages/Settings.py")
+    _state(at)
+    at.run()
+    assert not at.exception


### PR DESCRIPTION
### Motivation
- Rendre l’application Streamlit plus professionnelle, modulaire et résiliente tout en conservant l’auth via `st.secrets` et Google Sheets comme source par défaut. 
- Ajouter un fallback CSV local, une vraie couche de qualité des données et une évaluation de prévision statistiquement correcte (backtesting). 
- Séparer la logique métier de l’UI pour rendre le code testable hors-Streamlit et faciliter la maintenance. 

### Description
- Réorganisation modulaire: nouveau dossier `app/core` (data, features, evaluation, forecasting, insights, models), `app/ui` (components, theme) et 5 pages UI (`Dashboard`, `Journal`, `Prévisions`, `Insights`, `Paramètres`) intégrées au point d’entrée refactoré (`Suivi_V1.py`). 
- Chargement et validation des données renforcés: `clean_weight_dataframe`, `validate_journal`, stratégies de gestion des doublons, rapport de qualité (`data_quality_report`) et parsing de dates robuste; fallback upload CSV local si Google Sheets indisponible. 
- Feature engineering et modèles: lags, rolling stats, IMC et bilan calorique dans `build_features`; modèles et quantile regressions pour générer intervalles de prédiction et SARIMAX pour IC temporelles. 
- Évaluation et backtesting: fonctions de backtest walk‑forward, métriques (MAE/RMSE/MAPE/sMAPE/biais/directional accuracy) et leaderboard de baselines (last, MA7, MA14, drift). 
- UI et ergonomie: `st.data_editor` pour le Journal, composants réutilisables (KPI, badges, bannières, états vides), `st.form` pour paramètres et `st.fragment` pour isoler blocs lourds; thèmes légers et textes d’aide en français. 
- Documentation et exemples mis à jour: `README.md`, `TECH_REPORT.md`, `CHANGELOG.md`, `docs/MODEL_CARD.md`. 

### Testing
- Tests unitaires exécutés avec `pytest -q` couvrant nettoyage, validation, feature engineering, backtesting, ETA objectif, détection de plateau et anomalies, et rapport qualité; résultat final: `28 passed, 1 warning`. 
- Smoke tests Streamlit via `streamlit.testing.v1.AppTest` pour chaque page principale ont été ajoutés et inclus dans la suite (`tests/test_streamlit_smoke.py`). 
- Les tests initiaux qui échouaient ont été corrigés pendant la refactorisation (parité des formats et compatibilité Pandas); la suite complète passe désormais en local.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27ba704108329b2223176dc3131ce)