### PR TITLE
Add explanatory captions and data-confidence warnings across Dashboard, Insights, and Predictions

### DIFF
--- a/app/pages/Dashboard.py
+++ b/app/pages/Dashboard.py
@@ -150,6 +150,7 @@ def main() -> None:
     progress = max(0.0, min(100.0, progress))
     st.progress(progress / 100)
     st.caption(f"{progress_label}: {progress:.1f}%")
+    st.caption("ℹ️ Les métriques marquées ⚠️ sont informatives, mais restent fragiles en phase de démarrage.")
 
     # ── Prochain milestone intelligent (AN4 — avec garde-fous C1/C3) ──
     v14 = vel.get(14)
@@ -286,7 +287,7 @@ def main() -> None:
             fig_ma.add_hline(y=float(target), line_dash="dash", annotation_text=f"Obj. {idx}")
         fig_ma.update_layout(title="Moyennes mobiles (glissantes sur N mesures consécutives)", hovermode="x unified")
         st.plotly_chart(fig_ma, use_container_width=True)
-        st.caption("ℹ️ Les moyennes mobiles glissent sur N mesures consécutives, pas sur N jours calendaires.")
+        st.caption("ℹ️ Les moyennes mobiles glissent sur N mesures consécutives (et non sur N jours calendaires).")
 
     # ── Comparaison hebdo (existant) ────────────────────────────────────
     wk_data = df[df["Date"] >= last_date - pd.Timedelta(days=7)]["Poids (Kgs)"]
@@ -296,6 +297,8 @@ def main() -> None:
     delta_wk = wk - prev_wk
     st.metric("Comparaison hebdo (7j calendaires)", f"{wk:.2f} kg", f"{delta_wk:+.2f} kg", delta_color="inverse",
              help=f"Semaine courante: {len(wk_data)} mesure(s) · Semaine précédente: {len(prev_wk_data)} mesure(s)")
+    if len(wk_data) < 3 or len(prev_wk_data) < 3:
+        st.caption("⚠️ Comparaison hebdo prudente: moins de 3 mesures sur au moins une des deux semaines.")
 
     # ── Volatilité (existant) ───────────────────────────────────────────
     vol = weight_volatility(analysis_df, window=14)

--- a/app/pages/Insights.py
+++ b/app/pages/Insights.py
@@ -79,6 +79,7 @@ def main() -> None:
 
     with st.expander("📋 Détails qualité (JSON)", expanded=False):
         st.json(quality)
+    st.caption("ℹ️ Plateau calculé sur des fenêtres de jours calendaires (14j et 30j), pas sur un nombre fixe de mesures.")
 
     plateau14 = detect_plateau(analysis_df, 14)
     plateau30 = detect_plateau(analysis_df, 30)
@@ -229,6 +230,7 @@ def main() -> None:
                       f"{w['current_mean']:.1f} vs {w['previous_mean']:.1f} kg")
         else:
             st.info("Données insuffisantes")
+        st.caption("Base de calcul: moyennes hebdomadaires calendaires.")
     with cmp_cols[1]:
         st.markdown("**Mois courant vs précédent**")
         if period["month"]:
@@ -239,6 +241,7 @@ def main() -> None:
                       f"{m['current_mean']:.1f} vs {m['previous_mean']:.1f} kg")
         else:
             st.info("Données insuffisantes")
+        st.caption("Base de calcul: moyennes mensuelles calendaires.")
 
     # ══════════════════════════════════════════════════════════════════════
     # Section 7 : Patterns par jour de la semaine (NOUVEAU)

--- a/app/pages/Predictions.py
+++ b/app/pages/Predictions.py
@@ -58,6 +58,7 @@ def _model_comparison(df: pd.DataFrame) -> None:
         })
     scores = pd.DataFrame(rows).sort_values("MAE")
     st.dataframe(scores, use_container_width=True)
+    st.caption("ℹ️ Évaluation sur découpage chronologique 80/20 (pas de mélange aléatoire temporel).")
 
 
 def _sarima_block(df: pd.DataFrame, horizon: int) -> None:
@@ -149,6 +150,7 @@ def _stl_acf_pacf_block(df: pd.DataFrame) -> None:
 def _scenarios_block(df: pd.DataFrame) -> None:
     """Scénarios prospectifs (NOUVEAU)."""
     st.subheader("🔮 Scénarios prospectifs")
+    st.caption("Scénarios basés sur des rythmes observés (fenêtres 7/14/30j), à interpréter comme guidance et non certitude.")
 
     target_weight = st.session_state.get("target_weight", 80.0)
     scenarios = prospective_scenarios(df, target_weight)
@@ -250,6 +252,7 @@ def main() -> None:
                 st.caption(f"Plage plausible: {eta_min.date()} → {eta_max.date()} | Confiance {eta.get('confidence', 0):.0%}")
     else:
         alert_banner(str(eta.get("message", "Estimation indisponible")), "warning")
+        st.caption("⚠️ L'ETA est volontairement bloqué quand le signal est jugé fragile par les garde-fous.")
 
     # Multi-scenario ETA (NOUVEAU)
     scenarios = eta.get("scenarios", {})
@@ -266,6 +269,7 @@ def main() -> None:
     st.markdown("---")
     st.subheader("📊 Vitesses de variation")
     vel = weight_velocity(df, windows=(7, 14, 30, 90))
+    st.caption("Convention: valeur négative = perte de poids, positive = prise de poids (kg/sem).")
     vel_cols = st.columns(4)
     for i, (w, v) in enumerate(vel.items()):
         with vel_cols[i]:


### PR DESCRIPTION
### Motivation
- Improve user guidance by making interpretation rules and data-confidence explicit to avoid misreading metrics when data are sparse or signals are fragile.
- Clarify calculation bases (calendar windows vs consecutive measurements) and evaluation methodology for predictive blocks to increase transparency.
- Surface simple guardrails and contextual notes around ETA/scenario outputs and weekly comparisons so users understand limitations of automated estimates.

### Description
- Dashboard: added an info caption about fragile metrics (`st.caption(

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a57b34b88329a0641699186fbf51)