### PR TITLE
Consolidate session data access and add UI guidance captions

### DIFF
--- a/app/core/session_state.py
+++ b/app/core/session_state.py
@@ -9,10 +9,18 @@ from app.config import ALL_COLUMNS
 
 
 DEFAULT_TARGETS = (95.0, 90.0, 85.0, 80.0)
+DEFAULT_WEIGHT_COLUMNS = ["Date", "Poids (Kgs)"]
 
 
 def _empty_df() -> pd.DataFrame:
     return pd.DataFrame(columns=list(ALL_COLUMNS))
+
+
+def get_filtered_or_working_data() -> pd.DataFrame:
+    return st.session_state.get(
+        "filtered_data",
+        st.session_state.get("working_data", pd.DataFrame(columns=DEFAULT_WEIGHT_COLUMNS)),
+    )
 
 
 def ensure_session_defaults() -> None:

--- a/app/pages/Dashboard.py
+++ b/app/pages/Dashboard.py
@@ -23,11 +23,12 @@ from app.core.analytics import (
 )
 from app.core.data import data_quality_report
 from app.core.insights import detect_plateau
+from app.core.session_state import get_filtered_or_working_data
 from app.ui.components import alert_banner, confidence_badge, empty_state, help_box, kpi_card
 
 
 def _df() -> pd.DataFrame:
-    return st.session_state.get("filtered_data", st.session_state.get("working_data", pd.DataFrame(columns=["Date", "Poids (Kgs)"])))
+    return get_filtered_or_working_data()
 
 
 def _moving_average(series: pd.Series, window: int, ma_type: str) -> pd.Series:
@@ -150,6 +151,7 @@ def main() -> None:
     progress = max(0.0, min(100.0, progress))
     st.progress(progress / 100)
     st.caption(f"{progress_label}: {progress:.1f}%")
+    st.caption("ℹ️ Les métriques marquées ⚠️ sont informatives, mais restent fragiles en phase de démarrage.")
 
     # ── Prochain milestone intelligent (AN4 — avec garde-fous C1/C3) ──
     v14 = vel.get(14)
@@ -286,7 +288,7 @@ def main() -> None:
             fig_ma.add_hline(y=float(target), line_dash="dash", annotation_text=f"Obj. {idx}")
         fig_ma.update_layout(title="Moyennes mobiles (glissantes sur N mesures consécutives)", hovermode="x unified")
         st.plotly_chart(fig_ma, use_container_width=True)
-        st.caption("ℹ️ Les moyennes mobiles glissent sur N mesures consécutives, pas sur N jours calendaires.")
+        st.caption("ℹ️ Les moyennes mobiles glissent sur N mesures consécutives (et non sur N jours calendaires).")
 
     # ── Comparaison hebdo (existant) ────────────────────────────────────
     wk_data = df[df["Date"] >= last_date - pd.Timedelta(days=7)]["Poids (Kgs)"]
@@ -296,6 +298,8 @@ def main() -> None:
     delta_wk = wk - prev_wk
     st.metric("Comparaison hebdo (7j calendaires)", f"{wk:.2f} kg", f"{delta_wk:+.2f} kg", delta_color="inverse",
              help=f"Semaine courante: {len(wk_data)} mesure(s) · Semaine précédente: {len(prev_wk_data)} mesure(s)")
+    if len(wk_data) < 3 or len(prev_wk_data) < 3:
+        st.caption("⚠️ Comparaison hebdo prudente: moins de 3 mesures sur au moins une des deux semaines.")
 
     # ── Volatilité (existant) ───────────────────────────────────────────
     vol = weight_volatility(analysis_df, window=14)

--- a/app/pages/Insights.py
+++ b/app/pages/Insights.py
@@ -21,11 +21,12 @@ from app.core.analytics import (
 )
 from app.core.data import data_quality_report
 from app.core.insights import detect_anomalies_robust, detect_plateau
+from app.core.session_state import get_filtered_or_working_data
 from app.ui.components import empty_state, kpi_card
 
 
 def _df() -> pd.DataFrame:
-    return st.session_state.get("filtered_data", st.session_state.get("working_data", pd.DataFrame(columns=["Date", "Poids (Kgs)"])))
+    return get_filtered_or_working_data()
 
 
 def main() -> None:
@@ -79,6 +80,7 @@ def main() -> None:
 
     with st.expander("📋 Détails qualité (JSON)", expanded=False):
         st.json(quality)
+    st.caption("ℹ️ Plateau calculé sur des fenêtres de jours calendaires (14j et 30j), pas sur un nombre fixe de mesures.")
 
     plateau14 = detect_plateau(analysis_df, 14)
     plateau30 = detect_plateau(analysis_df, 30)
@@ -229,6 +231,7 @@ def main() -> None:
                       f"{w['current_mean']:.1f} vs {w['previous_mean']:.1f} kg")
         else:
             st.info("Données insuffisantes")
+        st.caption("Base de calcul: moyennes hebdomadaires calendaires.")
     with cmp_cols[1]:
         st.markdown("**Mois courant vs précédent**")
         if period["month"]:
@@ -239,6 +242,7 @@ def main() -> None:
                       f"{m['current_mean']:.1f} vs {m['previous_mean']:.1f} kg")
         else:
             st.info("Données insuffisantes")
+        st.caption("Base de calcul: moyennes mensuelles calendaires.")
 
     # ══════════════════════════════════════════════════════════════════════
     # Section 7 : Patterns par jour de la semaine (NOUVEAU)

--- a/app/pages/Predictions.py
+++ b/app/pages/Predictions.py
@@ -17,13 +17,14 @@ from app.core.evaluation import evaluate_baselines
 from app.core.features import build_features
 from app.core.forecasting import forecast_with_ml, forecast_with_sarimax
 from app.core.insights import estimate_target_eta
+from app.core.session_state import get_filtered_or_working_data
 from app.ui.components import alert_banner, empty_state, kpi_card
 
 warnings.filterwarnings("ignore")
 
 
 def _df() -> pd.DataFrame:
-    return st.session_state.get("filtered_data", st.session_state.get("working_data", pd.DataFrame(columns=["Date", "Poids (Kgs)"])))
+    return get_filtered_or_working_data()
 
 
 def _model_comparison(df: pd.DataFrame) -> None:
@@ -58,6 +59,7 @@ def _model_comparison(df: pd.DataFrame) -> None:
         })
     scores = pd.DataFrame(rows).sort_values("MAE")
     st.dataframe(scores, use_container_width=True)
+    st.caption("ℹ️ Évaluation sur découpage chronologique 80/20 (pas de mélange aléatoire temporel).")
 
 
 def _sarima_block(df: pd.DataFrame, horizon: int) -> None:
@@ -149,6 +151,7 @@ def _stl_acf_pacf_block(df: pd.DataFrame) -> None:
 def _scenarios_block(df: pd.DataFrame) -> None:
     """Scénarios prospectifs (NOUVEAU)."""
     st.subheader("🔮 Scénarios prospectifs")
+    st.caption("Scénarios basés sur des rythmes observés (fenêtres 7/14/30j), à interpréter comme guidance et non certitude.")
 
     target_weight = st.session_state.get("target_weight", 80.0)
     scenarios = prospective_scenarios(df, target_weight)
@@ -250,6 +253,7 @@ def main() -> None:
                 st.caption(f"Plage plausible: {eta_min.date()} → {eta_max.date()} | Confiance {eta.get('confidence', 0):.0%}")
     else:
         alert_banner(str(eta.get("message", "Estimation indisponible")), "warning")
+        st.caption("⚠️ L'ETA est volontairement bloqué quand le signal est jugé fragile par les garde-fous.")
 
     # Multi-scenario ETA (NOUVEAU)
     scenarios = eta.get("scenarios", {})
@@ -266,6 +270,7 @@ def main() -> None:
     st.markdown("---")
     st.subheader("📊 Vitesses de variation")
     vel = weight_velocity(df, windows=(7, 14, 30, 90))
+    st.caption("Convention: valeur négative = perte de poids, positive = prise de poids (kg/sem).")
     vel_cols = st.columns(4)
     for i, (w, v) in enumerate(vel.items()):
         with vel_cols[i]:


### PR DESCRIPTION
### Motivation
- Centralize the logic that picks the dataset to display (prefer `filtered_data` then `working_data`) to avoid repeated inline defaults across pages.
- Improve UX by adding contextual captions and warnings about metric fragility, calculation bases, and evaluation conventions.

### Description
- Add `DEFAULT_WEIGHT_COLUMNS` and a helper `get_filtered_or_working_data()` in `app/core/session_state.py` to return `filtered_data` or fall back to `working_data` with a consistent default schema.
- Replace repeated inline session lookup with `get_filtered_or_working_data()` in `app/pages/Dashboard.py`, `app/pages/Insights.py`, and `app/pages/Predictions.py`.
- Add several UI captions and warnings across pages: informative note about fragile metrics in `Dashboard.py`, clarification on moving average wording, weekly comparison warning when there are fewer than 3 measurements, captions in `Insights.py` about plateau calculation and period bases, and multiple explanatory captions in `Predictions.py` (model evaluation note, scenarios guidance, ETA blocking note, velocity convention).
- Minor text wording tweak for moving-average caption.

### Testing
- Ran the project import checks and started the Streamlit pages locally to verify the pages load and the new helper is used without import errors.
- Ran the project's test suite with `pytest` and static checks; no test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a57b34b88329a0641699186fbf51)