### PR TITLE
Set dashboard target trajectory to -2 kg/week

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Application Streamlit de suivi de poids avec analyses comportementales avancées
 | **Tendance EMA** | Poids lissé comme KPI principal (filtre les fluctuations quotidiennes) |
 | **Détection yo-yo** | Analyse factuelle des rebonds après chaque pause de suivi |
 | **Détection d'effort** | Identification automatique de la période d'effort actuelle (gap > 21j = nouveau départ) |
-| **Trajectoire cible** | Corridor ±1 kg autour d'une pente saine de -0.5 kg/sem |
+| **Trajectoire cible** | Corridor ±1 kg autour d'une pente cible de -2 kg/sem |
 | **Phase de démarrage** | Les 7 premiers jours = "données fragiles", pas d'extrapolation |
 | **Milestone intelligent** | Prochain palier avec ETA réaliste (gardes-fous physiologiques) |
 | **Vue hebdomadaire** | Bar chart consolidé avec coloration baisse/hausse |
@@ -145,7 +145,7 @@ Google Sheets CSV ──► load_remote_csv() ──► clean_weight_dataframe()
 - **Pattern yo-yo** : alerte factuelle si rebond détecté + meilleur effort passé
 - **🧭 Résumé actionnable** : Situation / Interprétation / Action (contextualisé)
 - 💡 Insights détaillés (expander)
-- **Graphique principal** : courbe poids + EMA + trajectoire cible (-0.5 kg/sem) + corridor ±1 kg
+- **Graphique principal** : courbe poids + EMA + trajectoire cible (-2 kg/sem) + corridor ±1 kg
 - Vue hebdomadaire consolidée (expander)
 - Multi-MA chart (expander)
 - Comparaison hebdo + volatilité

--- a/app/pages/Dashboard.py
+++ b/app/pages/Dashboard.py
@@ -241,10 +241,10 @@ def main() -> None:
     for idx, target in enumerate(targets, start=1):
         fig.add_hline(y=float(target), line_dash="dash", annotation_text=f"Objectif {idx}: {target:.1f} kg")
 
-    # AN1: Trajectoire cible depuis début de l'effort (pente saine = -0.5 kg/sem)
+    # AN1: Trajectoire cible depuis début de l'effort (pente cible = -2 kg/sem)
     if has_effort_period:
         effort_initial_w = float(effort_df["Poids (Kgs)"].iloc[0])
-        healthy_rate = -0.5 / 7  # kg/jour
+        healthy_rate = -2.0 / 7  # kg/jour
         # Tracer sur 180 jours max depuis début effort
         traj_dates = pd.date_range(effort_start, periods=min(180, max(effort_days * 3, 90)), freq="D")
         traj_values = [effort_initial_w + healthy_rate * i for i in range(len(traj_dates))]
@@ -252,7 +252,7 @@ def main() -> None:
         traj_values = [max(v, target_weight) for v in traj_values]
 
         fig.add_scatter(x=traj_dates, y=traj_values, mode="lines",
-                        name="Trajectoire cible (-0.5 kg/sem)",
+                        name="Trajectoire cible (-2 kg/sem)",
                         line=dict(color="#27AE60", width=2, dash="dashdot"))
 
         # Corridor ±1 kg


### PR DESCRIPTION
### Motivation
- Update the dashboard target trajectory to aim for a faster pace (2 kg/week instead of 0.5 kg/week) for the evolution visualization.

### Description
- Change `healthy_rate` from `-0.5 / 7` to `-2.0 / 7` and update the trajectory legend to `"Trajectoire cible (-2 kg/sem)"` in `app/pages/Dashboard.py`, and update the `README.md` copy to reflect the new target pace.

### Testing
- Attempted to run `pytest -q tests/test_streamlit_smoke.py`, but the run failed due to a missing dependency (`numpy`), so automated tests could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a183a1a2c4883299f76eb4415be3a55)