### PR TITLE
Use -2 kg/week as target trajectory and update dashboard/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Application Streamlit de suivi de poids avec analyses comportementales avancées
 | **Tendance EMA** | Poids lissé comme KPI principal (filtre les fluctuations quotidiennes) |
 | **Détection yo-yo** | Analyse factuelle des rebonds après chaque pause de suivi |
 | **Détection d'effort** | Identification automatique de la période d'effort actuelle (gap > 21j = nouveau départ) |
-| **Trajectoire cible** | Corridor ±1 kg autour d'une pente saine de -0.5 kg/sem |
+| **Trajectoire cible** | Corridor ±1 kg autour d'une pente cible de -2 kg/sem |
 | **Phase de démarrage** | Les 7 premiers jours = "données fragiles", pas d'extrapolation |
 | **Milestone intelligent** | Prochain palier avec ETA réaliste (gardes-fous physiologiques) |
 | **Vue hebdomadaire** | Bar chart consolidé avec coloration baisse/hausse |
@@ -145,7 +145,7 @@ Google Sheets CSV ──► load_remote_csv() ──► clean_weight_dataframe()
 - **Pattern yo-yo** : alerte factuelle si rebond détecté + meilleur effort passé
 - **🧭 Résumé actionnable** : Situation / Interprétation / Action (contextualisé)
 - 💡 Insights détaillés (expander)
-- **Graphique principal** : courbe poids + EMA + trajectoire cible (-0.5 kg/sem) + corridor ±1 kg
+- **Graphique principal** : courbe poids + EMA + trajectoire cible (-2 kg/sem) + corridor ±1 kg
 - Vue hebdomadaire consolidée (expander)
 - Multi-MA chart (expander)
 - Comparaison hebdo + volatilité

--- a/app/pages/Dashboard.py
+++ b/app/pages/Dashboard.py
@@ -27,6 +27,12 @@ from app.core.session_state import get_filtered_or_working_data
 from app.ui.components import alert_banner, confidence_badge, empty_state, help_box, kpi_card
 
 
+TARGET_TRAJECTORY_KG_PER_WEEK = -2.0
+TARGET_TRAJECTORY_DAILY_RATE = TARGET_TRAJECTORY_KG_PER_WEEK / 7
+TARGET_TRAJECTORY_LABEL = "Trajectoire cible (-2 kg/sem)"
+TARGET_TRAJECTORY_CHART_KEY = "dashboard_weight_evolution_target_minus_2kg_week_v2"
+
+
 def _df() -> pd.DataFrame:
     return get_filtered_or_working_data()
 
@@ -241,19 +247,20 @@ def main() -> None:
     for idx, target in enumerate(targets, start=1):
         fig.add_hline(y=float(target), line_dash="dash", annotation_text=f"Objectif {idx}: {target:.1f} kg")
 
-    # AN1: Trajectoire cible depuis début de l'effort (pente saine = -0.5 kg/sem)
+    # AN1: Trajectoire cible depuis début de l'effort (pente cible = -2 kg/sem)
     if has_effort_period:
         effort_initial_w = float(effort_df["Poids (Kgs)"].iloc[0])
-        healthy_rate = -0.5 / 7  # kg/jour
+        target_daily_rate = TARGET_TRAJECTORY_DAILY_RATE  # kg/jour
         # Tracer sur 180 jours max depuis début effort
         traj_dates = pd.date_range(effort_start, periods=min(180, max(effort_days * 3, 90)), freq="D")
-        traj_values = [effort_initial_w + healthy_rate * i for i in range(len(traj_dates))]
+        traj_values = [effort_initial_w + target_daily_rate * i for i in range(len(traj_dates))]
         # Ne pas descendre en dessous de l'objectif final
         traj_values = [max(v, target_weight) for v in traj_values]
 
         fig.add_scatter(x=traj_dates, y=traj_values, mode="lines",
-                        name="Trajectoire cible (-0.5 kg/sem)",
-                        line=dict(color="#27AE60", width=2, dash="dashdot"))
+                        name=TARGET_TRAJECTORY_LABEL,
+                        line=dict(color="#27AE60", width=2, dash="dashdot"),
+                        hovertemplate="Cible -2 kg/semaine<br>%{x|%d/%m/%Y}: %{y:.1f} kg<extra></extra>")
 
         # Corridor ±1 kg
         traj_upper = [v + 1.0 for v in traj_values]
@@ -268,7 +275,8 @@ def main() -> None:
         fig.add_vrect(x0=effort_start, x1=last_date, fillcolor="rgba(39,174,96,0.05)",
                       annotation_text="Effort actuel", line_width=0)
 
-    st.plotly_chart(fig, use_container_width=True)
+    st.caption("🎯 Trajectoire cible du graphique : **-2 kg/semaine**.")
+    st.plotly_chart(fig, use_container_width=True, key=TARGET_TRAJECTORY_CHART_KEY)
 
     # ── Vue hebdomadaire consolidée (AN3 — NOUVEAU) ─────────────────────
     with st.expander("📊 Vue hebdomadaire consolidée", expanded=False):


### PR DESCRIPTION
### Motivation
- Standardize the target trajectory used in the dashboard and documentation by replacing the previous -0.5 kg/week reference with an explicit -2 kg/week target. 
- Make the trajectory value explicit as constants to improve maintainability and enable a stable plot key and clearer chart labeling.

### Description
- Add constants `TARGET_TRAJECTORY_KG_PER_WEEK`, `TARGET_TRAJECTORY_DAILY_RATE`, `TARGET_TRAJECTORY_LABEL`, and `TARGET_TRAJECTORY_CHART_KEY` to `app/pages/Dashboard.py` and use them when computing and rendering the target trajectory. 
- Replace the hardcoded slope `-0.5/7` (kg/day) with `TARGET_TRAJECTORY_DAILY_RATE` and update the plotted trajectory name and hover template to show `-2 kg/semaine`. 
- Add a caption `"🎯 Trajectoire cible du graphique : **-2 kg/semaine**."` and pass `key=TARGET_TRAJECTORY_CHART_KEY` to `st.plotly_chart` for stable rendering. 
- Update `README.md` to reflect the new target trajectory wording in the features table and the dashboard graph description.

### Testing
- Ran the existing unit test suite with `pytest` (59 tests) and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a183a1a2c4883299f76eb4415be3a55)