### PR TITLE
Introduce -2 kg/week trajectory constants in Dashboard and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Application Streamlit de suivi de poids avec analyses comportementales avancées
 | **Tendance EMA** | Poids lissé comme KPI principal (filtre les fluctuations quotidiennes) |
 | **Détection yo-yo** | Analyse factuelle des rebonds après chaque pause de suivi |
 | **Détection d'effort** | Identification automatique de la période d'effort actuelle (gap > 21j = nouveau départ) |
-| **Trajectoire cible** | Corridor ±1 kg autour d'une pente cible de -2 kg/sem |
+| **Trajectoire cible** | Corridor ±1 kg autour d'une pente cible de -2 kg/semaine |
 | **Phase de démarrage** | Les 7 premiers jours = "données fragiles", pas d'extrapolation |
 | **Milestone intelligent** | Prochain palier avec ETA réaliste (gardes-fous physiologiques) |
 | **Vue hebdomadaire** | Bar chart consolidé avec coloration baisse/hausse |
@@ -145,7 +145,7 @@ Google Sheets CSV ──► load_remote_csv() ──► clean_weight_dataframe()
 - **Pattern yo-yo** : alerte factuelle si rebond détecté + meilleur effort passé
 - **🧭 Résumé actionnable** : Situation / Interprétation / Action (contextualisé)
 - 💡 Insights détaillés (expander)
-- **Graphique principal** : courbe poids + EMA + trajectoire cible (-2 kg/sem) + corridor ±1 kg
+- **Graphique principal** : courbe poids + EMA + trajectoire cible (-2 kg/semaine) + corridor ±1 kg
 - Vue hebdomadaire consolidée (expander)
 - Multi-MA chart (expander)
 - Comparaison hebdo + volatilité

--- a/app/pages/Dashboard.py
+++ b/app/pages/Dashboard.py
@@ -27,6 +27,12 @@ from app.core.session_state import get_filtered_or_working_data
 from app.ui.components import alert_banner, confidence_badge, empty_state, help_box, kpi_card
 
 
+TARGET_TRAJECTORY_KG_PER_WEEK = -2.0
+TARGET_TRAJECTORY_DAILY_RATE = TARGET_TRAJECTORY_KG_PER_WEEK / 7
+TARGET_TRAJECTORY_LABEL = f"Trajectoire cible ({TARGET_TRAJECTORY_KG_PER_WEEK:g} kg/semaine)"
+TARGET_TRAJECTORY_CHART_KEY = "dashboard-target-trajectory-2kg-week"
+
+
 def _df() -> pd.DataFrame:
     return get_filtered_or_working_data()
 
@@ -241,19 +247,27 @@ def main() -> None:
     for idx, target in enumerate(targets, start=1):
         fig.add_hline(y=float(target), line_dash="dash", annotation_text=f"Objectif {idx}: {target:.1f} kg")
 
-    # AN1: Trajectoire cible depuis début de l'effort (pente cible = -2 kg/sem)
+    # AN1: Trajectoire cible depuis début de l'effort (pente cible = -2 kg/semaine)
     if has_effort_period:
         effort_initial_w = float(effort_df["Poids (Kgs)"].iloc[0])
-        healthy_rate = -2.0 / 7  # kg/jour
         # Tracer sur 180 jours max depuis début effort
         traj_dates = pd.date_range(effort_start, periods=min(180, max(effort_days * 3, 90)), freq="D")
-        traj_values = [effort_initial_w + healthy_rate * i for i in range(len(traj_dates))]
+        traj_values = [effort_initial_w + TARGET_TRAJECTORY_DAILY_RATE * i for i in range(len(traj_dates))]
         # Ne pas descendre en dessous de l'objectif final
         traj_values = [max(v, target_weight) for v in traj_values]
 
-        fig.add_scatter(x=traj_dates, y=traj_values, mode="lines",
-                        name="Trajectoire cible (-2 kg/sem)",
-                        line=dict(color="#27AE60", width=2, dash="dashdot"))
+        fig.add_scatter(
+            x=traj_dates,
+            y=traj_values,
+            mode="lines",
+            name=TARGET_TRAJECTORY_LABEL,
+            line=dict(color="#27AE60", width=2, dash="dashdot"),
+            hovertemplate=(
+                "Date: %{x|%d/%m/%Y}<br>"
+                "Poids cible: %{y:.1f} kg<br>"
+                f"Rythme: {TARGET_TRAJECTORY_KG_PER_WEEK:g} kg/semaine<extra></extra>"
+            ),
+        )
 
         # Corridor ±1 kg
         traj_upper = [v + 1.0 for v in traj_values]
@@ -268,7 +282,8 @@ def main() -> None:
         fig.add_vrect(x0=effort_start, x1=last_date, fillcolor="rgba(39,174,96,0.05)",
                       annotation_text="Effort actuel", line_width=0)
 
-    st.plotly_chart(fig, use_container_width=True)
+    st.caption(f"🎯 Trajectoire cible du graphique : **{TARGET_TRAJECTORY_KG_PER_WEEK:g} kg/semaine**.")
+    st.plotly_chart(fig, use_container_width=True, key=TARGET_TRAJECTORY_CHART_KEY)
 
     # ── Vue hebdomadaire consolidée (AN3 — NOUVEAU) ─────────────────────
     with st.expander("📊 Vue hebdomadaire consolidée", expanded=False):


### PR DESCRIPTION
### Motivation
- Standardiser la trajectoire cible affichée (remplacer le calcul hardcodé) pour améliorer la maintenabilité et l’affichage. 
- Rendre la valeur cible explicite et réutilisable afin d’avoir un libellé/hover et une clé de rendu Plotly stables.

### Description
- Ajout de constantes dans `app/pages/Dashboard.py`: `TARGET_TRAJECTORY_KG_PER_WEEK`, `TARGET_TRAJECTORY_DAILY_RATE`, `TARGET_TRAJECTORY_LABEL` et `TARGET_TRAJECTORY_CHART_KEY` et utilisation de celles-ci pour le tracé. 
- Remplacement du slope hardcodé par `TARGET_TRAJECTORY_DAILY_RATE` et mise à jour du `hovertemplate` et du `name` de la courbe pour afficher `-2 kg/semaine`. 
- Ajout d’une caption indiquant la trajectoire cible et passage de `key=TARGET_TRAJECTORY_CHART_KEY` à `st.plotly_chart` pour un rendu stable. 
- Mise à jour de `README.md` pour harmoniser la formulation en `-2 kg/semaine` dans la table des fonctionnalités et la description du graphique.

### Testing
- `python -m py_compile app/pages/Dashboard.py` exécuté avec succès. 
- Exécution de `pytest` bloquée par l’environnement en local en raison d’une dépendance manquante (`numpy`), empêchant le lancement de la suite de tests automatisés. 
- Tentative d’installation des dépendances via `python -m pip install -r requirements.txt` bloquée par l’accès au dépôt de paquets (erreur tunnel/403) et échec d’installation d’un package (`matplotlib`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a184e53216483299c2dd1d961ec38cf)