### PR TITLE
Add fifth weight objective

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -32,7 +32,7 @@ class AppDefaults:
     """Valeurs par défaut modifiables via l'UI."""
 
     height_cm: int = 182
-    target_weight: float = 80.0
+    target_weight: float = 90.0
     confidence_level: float = 0.9
     duplicate_strategy: str = "garder_la_derniere"
     default_model: str = "ridge"

--- a/app/core/session_state.py
+++ b/app/core/session_state.py
@@ -8,7 +8,7 @@ import streamlit as st
 from app.config import ALL_COLUMNS
 
 
-DEFAULT_TARGETS = (95.0, 90.0, 85.0, 80.0)
+DEFAULT_TARGETS = (100.0, 95.0, 90.0, 85.0, 90.0)
 DEFAULT_WEIGHT_COLUMNS = ["Date", "Poids (Kgs)"]
 
 
@@ -30,6 +30,7 @@ def ensure_session_defaults() -> None:
     st.session_state.setdefault("filtered_data", _empty_df())
 
     st.session_state.setdefault("target_weights", DEFAULT_TARGETS)
+    st.session_state.setdefault("target_weight", DEFAULT_TARGETS[-1])
     st.session_state.setdefault("ma_type", "Simple")
     st.session_state.setdefault("window_size", 7)
     st.session_state.setdefault("theme", "plotly")

--- a/app/pages/Dashboard.py
+++ b/app/pages/Dashboard.py
@@ -23,7 +23,7 @@ from app.core.analytics import (
 )
 from app.core.data import data_quality_report
 from app.core.insights import detect_plateau
-from app.core.session_state import get_filtered_or_working_data
+from app.core.session_state import DEFAULT_TARGETS, get_filtered_or_working_data
 from app.ui.components import alert_banner, confidence_badge, empty_state, help_box, kpi_card
 
 
@@ -74,8 +74,8 @@ def main() -> None:
 
     height_m = st.session_state.get("height_m", 1.82)
     imc = current / (height_m**2)
-    targets = st.session_state.get("target_weights", (95.0, 90.0, 85.0, 80.0))
-    target_weight = st.session_state.get("target_weight", 80.0)
+    targets = st.session_state.get("target_weights", DEFAULT_TARGETS)
+    target_weight = st.session_state.get("target_weight", float(targets[-1]))
 
     # ── Bannière période d'effort (A1) ──────────────────────────────────
     if has_effort_period:

--- a/app/pages/Predictions.py
+++ b/app/pages/Predictions.py
@@ -17,7 +17,7 @@ from app.core.evaluation import evaluate_baselines
 from app.core.features import build_features
 from app.core.forecasting import forecast_with_ml, forecast_with_sarimax
 from app.core.insights import estimate_target_eta
-from app.core.session_state import get_filtered_or_working_data
+from app.core.session_state import DEFAULT_TARGETS, get_filtered_or_working_data
 from app.ui.components import alert_banner, empty_state, kpi_card
 
 warnings.filterwarnings("ignore")
@@ -153,7 +153,7 @@ def _scenarios_block(df: pd.DataFrame) -> None:
     st.subheader("🔮 Scénarios prospectifs")
     st.caption("Scénarios basés sur des rythmes observés (fenêtres 7/14/30j), à interpréter comme guidance et non certitude.")
 
-    target_weight = st.session_state.get("target_weight", 80.0)
+    target_weight = st.session_state.get("target_weight", DEFAULT_TARGETS[-1])
     scenarios = prospective_scenarios(df, target_weight)
 
     if not scenarios:
@@ -234,7 +234,7 @@ def main() -> None:
 
     # ── ETA objectif amélioré (existant + enrichi) ──────────────────────
     st.markdown("---")
-    target_weight = st.session_state.get("target_weight", 80.0)
+    target_weight = st.session_state.get("target_weight", DEFAULT_TARGETS[-1])
 
     # QW3: Utiliser la période d'effort pour l'ETA
     from app.core.analytics import detect_current_effort

--- a/app/pages/Settings.py
+++ b/app/pages/Settings.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import streamlit as st
 
 from app.config import AppDefaults, DUPLICATE_STRATEGIES
+from app.core.session_state import DEFAULT_TARGETS
 
 
 def main() -> None:
@@ -13,11 +14,13 @@ def main() -> None:
         target = st.number_input("Poids objectif final (kg)", value=float(st.session_state.get("target_weight", defaults.target_weight)))
         height_cm = st.number_input("Taille (cm)", value=float(st.session_state.get("height_cm", defaults.height_cm)))
 
-        goals = st.session_state.get("target_weights", (95.0, 90.0, 85.0, float(target)))
-        g1 = st.number_input("Objectif 1 (kg)", value=float(goals[0]))
-        g2 = st.number_input("Objectif 2 (kg)", value=float(goals[1]))
-        g3 = st.number_input("Objectif 3 (kg)", value=float(goals[2]))
-        g4 = st.number_input("Objectif 4 (kg)", value=float(goals[3] if len(goals) > 3 else target))
+        goals = tuple(st.session_state.get("target_weights", DEFAULT_TARGETS))
+        padded_goals = goals + DEFAULT_TARGETS[len(goals):]
+        g1 = st.number_input("Objectif 1 (kg)", value=float(padded_goals[0]))
+        g2 = st.number_input("Objectif 2 (kg)", value=float(padded_goals[1]))
+        g3 = st.number_input("Objectif 3 (kg)", value=float(padded_goals[2]))
+        g4 = st.number_input("Objectif 4 (kg)", value=float(padded_goals[3]))
+        g5 = st.number_input("Objectif 5 (kg)", value=float(padded_goals[4]))
 
         ma_type = st.selectbox("Type de moyenne mobile", ["Simple", "Exponentielle"], index=0 if st.session_state.get("ma_type", "Simple") == "Simple" else 1)
         window_size = st.slider("Fenêtre moyenne mobile", min_value=3, max_value=60, value=int(st.session_state.get("window_size", 7)))
@@ -29,7 +32,7 @@ def main() -> None:
 
     if submitted:
         st.session_state["target_weight"] = float(target)
-        st.session_state["target_weights"] = (float(g1), float(g2), float(g3), float(g4))
+        st.session_state["target_weights"] = (float(g1), float(g2), float(g3), float(g4), float(g5))
         st.session_state["height_cm"] = float(height_cm)
         st.session_state["height_m"] = float(height_cm) / 100
         st.session_state["duplicate_strategy"] = duplicate

--- a/tests/test_streamlit_smoke.py
+++ b/tests/test_streamlit_smoke.py
@@ -16,7 +16,7 @@ def _state(at: AppTest) -> None:
     at.session_state["working_data"] = df.copy()
     at.session_state["filtered_data"] = df.copy()
     at.session_state["raw_data"] = df.copy()
-    at.session_state["target_weights"] = (93.0, 90.0, 87.0, 84.0)
+    at.session_state["target_weights"] = (100.0, 95.0, 90.0, 85.0, 90.0)
     at.session_state["fast_mode"] = True
 
 
@@ -67,7 +67,7 @@ def test_predictions_render_multiple_sections_even_if_submodel_fails():
     assert any("Auto-ARIMA" in t for t in tab_labels)
 
 
-def test_settings_exposes_four_goals():
+def test_settings_exposes_five_goals():
     at = AppTest.from_file("app/pages/Settings.py")
     _state(at)
     at.run(timeout=10)
@@ -77,3 +77,4 @@ def test_settings_exposes_four_goals():
     assert "Objectif 2 (kg)" in labels
     assert "Objectif 3 (kg)" in labels
     assert "Objectif 4 (kg)" in labels
+    assert "Objectif 5 (kg)" in labels


### PR DESCRIPTION
### Motivation
- Supporter la demande d’afficher cinq objectifs de poids pour le graphique et la configuration utilisateur (ajout d’un cinquième palier). 
- Fournir un ensemble de valeurs par défaut centralisé réutilisable par le `Dashboard`, `Predictions` et `Settings` pour éviter des valeurs magiques dispersées. 

### Description
- Remplace `DEFAULT_TARGETS` dans `app/core/session_state.py` par ` (100.0, 95.0, 90.0, 85.0, 90.0)` et initialise `target_weight` en session sur `DEFAULT_TARGETS[-1]`. 
- Met à jour `app/pages/Settings.py` pour afficher un champ supplémentaire `Objectif 5 (kg)`, pour construire un `padded_goals` à partir de `DEFAULT_TARGETS` et pour persister les cinq objectifs dans `st.session_state["target_weights"]`. 
- Adapte `app/pages/Dashboard.py` et `app/pages/Predictions.py` pour importer `DEFAULT_TARGETS` et l’utiliser comme valeur de secours pour `targets` et `target_weight` (utilisation de `DEFAULT_TARGETS[-1]` comme objectif final par défaut). 
- Met à jour le test Streamlit `tests/test_streamlit_smoke.py` pour initialiser la session avec cinq objectifs et pour vérifier la présence de `Objectif 5 (kg)` dans l’UI tests. 

### Testing
- Syntax check succeeded: `python -m py_compile app/core/session_state.py app/config.py app/pages/Settings.py app/pages/Dashboard.py app/pages/Predictions.py tests/test_streamlit_smoke.py` (no syntax errors). 
- Smoke tests attempted: `pytest tests/test_streamlit_smoke.py tests/test_v3_guardrails.py` but execution was blocked by missing runtime dependency: `ModuleNotFoundError: No module named 'numpy'`. 
- Dependency install attempted: `python -m pip install -r requirements.txt` but failed due to network/package index access (tunnel returned `403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a195c7fc5488329a2a2b27fd30dd7b0)