### PR TITLE
Support five target weights, migrate legacy 4-goal sessions, and render target lines with improved annotations

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -32,7 +32,7 @@ class AppDefaults:
     """Valeurs par défaut modifiables via l'UI."""
 
     height_cm: int = 182
-    target_weight: float = 80.0
+    target_weight: float = 90.0
     confidence_level: float = 0.9
     duplicate_strategy: str = "garder_la_derniere"
     default_model: str = "ridge"

--- a/app/core/session_state.py
+++ b/app/core/session_state.py
@@ -8,8 +8,37 @@ import streamlit as st
 from app.config import ALL_COLUMNS
 
 
-DEFAULT_TARGETS = (95.0, 90.0, 85.0, 80.0)
+DEFAULT_TARGETS = (100.0, 95.0, 90.0, 85.0, 90.0)
 DEFAULT_WEIGHT_COLUMNS = ["Date", "Poids (Kgs)"]
+
+
+def normalise_target_weights(targets: object | None) -> tuple[float, ...]:
+    """Retourne toujours les 5 objectifs attendus pour les graphiques.
+
+    Les anciennes sessions Streamlit peuvent encore contenir les 4 anciens
+    objectifs (95, 90, 85, 80). Dans ce cas, on force les nouveaux paliers
+    demandés pour éviter de réafficher l'ancien graphique après déploiement.
+    """
+    if targets is None:
+        return DEFAULT_TARGETS
+
+    try:
+        values = tuple(float(target) for target in targets)
+    except (TypeError, ValueError):
+        return DEFAULT_TARGETS
+
+    if len(values) != len(DEFAULT_TARGETS):
+        return DEFAULT_TARGETS
+
+    return values
+
+
+def get_target_weights() -> tuple[float, ...]:
+    """Lit, corrige et persiste les objectifs de poids de la session."""
+    targets = normalise_target_weights(st.session_state.get("target_weights"))
+    st.session_state["target_weights"] = targets
+    st.session_state["target_weight"] = float(targets[-1])
+    return targets
 
 
 def _empty_df() -> pd.DataFrame:
@@ -29,7 +58,9 @@ def ensure_session_defaults() -> None:
     st.session_state.setdefault("working_data", _empty_df())
     st.session_state.setdefault("filtered_data", _empty_df())
 
-    st.session_state.setdefault("target_weights", DEFAULT_TARGETS)
+    targets = normalise_target_weights(st.session_state.get("target_weights"))
+    st.session_state["target_weights"] = targets
+    st.session_state["target_weight"] = float(targets[-1])
     st.session_state.setdefault("ma_type", "Simple")
     st.session_state.setdefault("window_size", 7)
     st.session_state.setdefault("theme", "plotly")

--- a/app/pages/Dashboard.py
+++ b/app/pages/Dashboard.py
@@ -23,7 +23,7 @@ from app.core.analytics import (
 )
 from app.core.data import data_quality_report
 from app.core.insights import detect_plateau
-from app.core.session_state import get_filtered_or_working_data
+from app.core.session_state import get_filtered_or_working_data, get_target_weights
 from app.ui.components import alert_banner, confidence_badge, empty_state, help_box, kpi_card
 
 
@@ -41,6 +41,28 @@ def _moving_average(series: pd.Series, window: int, ma_type: str) -> pd.Series:
     if ma_type == "Exponentielle":
         return series.ewm(span=max(window, 2), adjust=False).mean()
     return series.rolling(window=window, min_periods=1).mean()
+
+
+def _target_annotation_shift(targets: tuple[float, ...], index: int) -> int:
+    """Décale les libellés quand deux objectifs ont la même valeur."""
+    current_target = targets[index]
+    duplicate_rank = sum(1 for target in targets[:index] if target == current_target)
+    return duplicate_rank * 16
+
+
+def _add_target_lines(fig: go.Figure, targets: tuple[float, ...], label_prefix: str = "Objectif") -> None:
+    for idx, target in enumerate(targets, start=1):
+        yshift = _target_annotation_shift(targets, idx - 1)
+        fig.add_hline(
+            y=float(target),
+            line_dash="dash",
+            annotation_text=f"{label_prefix} {idx}: {target:.1f} kg",
+            annotation_yshift=yshift,
+        )
+
+
+def _targets_caption(targets: tuple[float, ...]) -> str:
+    return " · ".join(f"Obj. {idx}: {target:.1f} kg" for idx, target in enumerate(targets, start=1))
 
 
 def main() -> None:
@@ -74,8 +96,8 @@ def main() -> None:
 
     height_m = st.session_state.get("height_m", 1.82)
     imc = current / (height_m**2)
-    targets = st.session_state.get("target_weights", (95.0, 90.0, 85.0, 80.0))
-    target_weight = st.session_state.get("target_weight", 80.0)
+    targets = get_target_weights()
+    target_weight = float(targets[-1])
 
     # ── Bannière période d'effort (A1) ──────────────────────────────────
     if has_effort_period:
@@ -244,8 +266,8 @@ def main() -> None:
                     line=dict(color="#E74C3C", width=2.5))
     fig.add_hline(y=float(df["Poids (Kgs)"].mean()), line_dash="dot", annotation_text="Moyenne globale")
 
-    for idx, target in enumerate(targets, start=1):
-        fig.add_hline(y=float(target), line_dash="dash", annotation_text=f"Objectif {idx}: {target:.1f} kg")
+    _add_target_lines(fig, targets)
+    st.caption(f"🎯 Objectifs affichés : {_targets_caption(targets)}")
 
     # AN1: Trajectoire cible depuis début de l'effort (pente cible = -2 kg/semaine)
     if has_effort_period:
@@ -299,8 +321,7 @@ def main() -> None:
         for col, color in colors.items():
             if col in df_ma.columns:
                 fig_ma.add_scatter(x=df_ma["Date"], y=df_ma[col], mode="lines", name=labels.get(col, col), line=dict(color=color, width=2))
-        for idx, target in enumerate(targets, start=1):
-            fig_ma.add_hline(y=float(target), line_dash="dash", annotation_text=f"Obj. {idx}")
+        _add_target_lines(fig_ma, targets, label_prefix="Obj.")
         fig_ma.update_layout(title="Moyennes mobiles (glissantes sur N mesures consécutives)", hovermode="x unified")
         st.plotly_chart(fig_ma, use_container_width=True)
         st.caption("ℹ️ Les moyennes mobiles glissent sur N mesures consécutives (et non sur N jours calendaires).")
@@ -398,8 +419,7 @@ def _render_weekly_view(df: pd.DataFrame, targets: tuple) -> None:
                    for _, row in display_weeks.iterrows()],
         hoverinfo="text",
     )
-    for idx, target in enumerate(targets, start=1):
-        fig_wk.add_hline(y=float(target), line_dash="dash", annotation_text=f"Obj. {idx}")
+    _add_target_lines(fig_wk, targets, label_prefix="Obj.")
     fig_wk.update_layout(
         title="Poids moyen par semaine (vert = baisse, rouge = hausse)",
         yaxis_title="Poids moyen (kg)",

--- a/app/pages/Predictions.py
+++ b/app/pages/Predictions.py
@@ -17,7 +17,7 @@ from app.core.evaluation import evaluate_baselines
 from app.core.features import build_features
 from app.core.forecasting import forecast_with_ml, forecast_with_sarimax
 from app.core.insights import estimate_target_eta
-from app.core.session_state import get_filtered_or_working_data
+from app.core.session_state import get_filtered_or_working_data, get_target_weights
 from app.ui.components import alert_banner, empty_state, kpi_card
 
 warnings.filterwarnings("ignore")
@@ -153,7 +153,7 @@ def _scenarios_block(df: pd.DataFrame) -> None:
     st.subheader("🔮 Scénarios prospectifs")
     st.caption("Scénarios basés sur des rythmes observés (fenêtres 7/14/30j), à interpréter comme guidance et non certitude.")
 
-    target_weight = st.session_state.get("target_weight", 80.0)
+    target_weight = float(get_target_weights()[-1])
     scenarios = prospective_scenarios(df, target_weight)
 
     if not scenarios:
@@ -234,7 +234,7 @@ def main() -> None:
 
     # ── ETA objectif amélioré (existant + enrichi) ──────────────────────
     st.markdown("---")
-    target_weight = st.session_state.get("target_weight", 80.0)
+    target_weight = float(get_target_weights()[-1])
 
     # QW3: Utiliser la période d'effort pour l'ETA
     from app.core.analytics import detect_current_effort

--- a/app/pages/Settings.py
+++ b/app/pages/Settings.py
@@ -3,21 +3,23 @@ from __future__ import annotations
 import streamlit as st
 
 from app.config import AppDefaults, DUPLICATE_STRATEGIES
+from app.core.session_state import get_target_weights
 
 
 def main() -> None:
     st.title("Paramètres / Qualité")
     defaults = AppDefaults()
+    goals = get_target_weights()
 
     with st.form("settings_form"):
         target = st.number_input("Poids objectif final (kg)", value=float(st.session_state.get("target_weight", defaults.target_weight)))
         height_cm = st.number_input("Taille (cm)", value=float(st.session_state.get("height_cm", defaults.height_cm)))
 
-        goals = st.session_state.get("target_weights", (95.0, 90.0, 85.0, float(target)))
         g1 = st.number_input("Objectif 1 (kg)", value=float(goals[0]))
         g2 = st.number_input("Objectif 2 (kg)", value=float(goals[1]))
         g3 = st.number_input("Objectif 3 (kg)", value=float(goals[2]))
-        g4 = st.number_input("Objectif 4 (kg)", value=float(goals[3] if len(goals) > 3 else target))
+        g4 = st.number_input("Objectif 4 (kg)", value=float(goals[3]))
+        g5 = st.number_input("Objectif 5 (kg)", value=float(goals[4]))
 
         ma_type = st.selectbox("Type de moyenne mobile", ["Simple", "Exponentielle"], index=0 if st.session_state.get("ma_type", "Simple") == "Simple" else 1)
         window_size = st.slider("Fenêtre moyenne mobile", min_value=3, max_value=60, value=int(st.session_state.get("window_size", 7)))
@@ -29,7 +31,7 @@ def main() -> None:
 
     if submitted:
         st.session_state["target_weight"] = float(target)
-        st.session_state["target_weights"] = (float(g1), float(g2), float(g3), float(g4))
+        st.session_state["target_weights"] = (float(g1), float(g2), float(g3), float(g4), float(g5))
         st.session_state["height_cm"] = float(height_cm)
         st.session_state["height_m"] = float(height_cm) / 100
         st.session_state["duplicate_strategy"] = duplicate

--- a/tests/test_streamlit_smoke.py
+++ b/tests/test_streamlit_smoke.py
@@ -16,7 +16,7 @@ def _state(at: AppTest) -> None:
     at.session_state["working_data"] = df.copy()
     at.session_state["filtered_data"] = df.copy()
     at.session_state["raw_data"] = df.copy()
-    at.session_state["target_weights"] = (93.0, 90.0, 87.0, 84.0)
+    at.session_state["target_weights"] = (100.0, 95.0, 90.0, 85.0, 90.0)
     at.session_state["fast_mode"] = True
 
 
@@ -28,6 +28,18 @@ def test_dashboard_renders_kpis_and_sections():
     assert any("Dashboard" in h.value for h in at.title)
     assert len(at.metric) >= 3
     assert any("objectif" in str(c.value).lower() for c in at.caption)
+
+
+def test_dashboard_migrates_legacy_four_goals_to_requested_five_goals():
+    at = AppTest.from_file("app/pages/Dashboard.py")
+    _state(at)
+    at.session_state["target_weights"] = (95.0, 90.0, 85.0, 80.0)
+    at.session_state["target_weight"] = 80.0
+    at.run(timeout=10)
+    assert not at.exception
+    assert at.session_state["target_weights"] == (100.0, 95.0, 90.0, 85.0, 90.0)
+    assert at.session_state["target_weight"] == 90.0
+    assert any("Obj. 5: 90.0 kg" in str(c.value) for c in at.caption)
 
 
 def test_journal_loads_and_keeps_state_on_navigation():
@@ -67,7 +79,7 @@ def test_predictions_render_multiple_sections_even_if_submodel_fails():
     assert any("Auto-ARIMA" in t for t in tab_labels)
 
 
-def test_settings_exposes_four_goals():
+def test_settings_exposes_five_goals():
     at = AppTest.from_file("app/pages/Settings.py")
     _state(at)
     at.run(timeout=10)
@@ -77,3 +89,4 @@ def test_settings_exposes_four_goals():
     assert "Objectif 2 (kg)" in labels
     assert "Objectif 3 (kg)" in labels
     assert "Objectif 4 (kg)" in labels
+    assert "Objectif 5 (kg)" in labels


### PR DESCRIPTION
### Motivation

- Add support for a fifth weight goal to allow richer goal configuration and to align the UI and charts with the requested five-goal display.
- Migrate older sessions that store four goals to the new five-goal format to avoid regressions after deploys.
- Surface the current final target consistently across pages and use it for projections and scenario calculations.
- Improve chart rendering of multiple target lines and avoid overlapping annotations when goals share the same value.

### Description

- Extend `DEFAULT_TARGETS` to a five-element tuple and change the default final `target_weight` in `AppDefaults` from `80.0` to `90.0` in `app/config.py`.
- Add `normalise_target_weights` and `get_target_weights` in `app/core/session_state.py` to validate, normalize and persist a five-element `target_weights` tuple for session state, and update `ensure_session_defaults` to use the normaliser.
- Update `app/pages/Dashboard.py` to use `get_target_weights`, add helper functions `_add_target_lines`, `_target_annotation_shift` and `_targets_caption` to draw annotated horizontal target lines with y-shifts for duplicate values, and surface a caption listing the displayed goals.
- Update `app/pages/Predictions.py` to use `get_target_weights` for scenarios and ETA calculations.
- Update `app/pages/Settings.py` to read the current goals via `get_target_weights`, expose a fifth `number_input` for `Objectif 5 (kg)` and persist a five-element `target_weights` tuple when saving settings.
- Adjusted smoke tests in `tests/test_streamlit_smoke.py` to initialize session state with five targets, added a migration test `test_dashboard_migrates_legacy_four_goals_to_requested_five_goals`, and updated the settings test to expect five goal inputs.

### Testing

- Ran the Streamlit smoke tests in `tests/test_streamlit_smoke.py` via `pytest tests/test_streamlit_smoke.py` and the suite passed without failures.
- Verified the migration scenario by a smoke test that starts with a legacy four-goal `target_weights` and asserts it is normalized to the new five-goal tuple.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a195c7fc5488329a2a2b27fd30dd7b0)