### PR TITLE
Update default weight objectives to end at 80 kg

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -32,7 +32,7 @@ class AppDefaults:
     """Valeurs par défaut modifiables via l'UI."""
 
     height_cm: int = 182
-    target_weight: float = 90.0
+    target_weight: float = 80.0
     confidence_level: float = 0.9
     duplicate_strategy: str = "garder_la_derniere"
     default_model: str = "ridge"

--- a/app/core/session_state.py
+++ b/app/core/session_state.py
@@ -12,7 +12,7 @@ import streamlit as st
 from app.config import ALL_COLUMNS
 
 
-DEFAULT_TARGETS = (100.0, 95.0, 90.0, 85.0, 90.0)
+DEFAULT_TARGETS = (100.0, 95.0, 90.0, 85.0, 80.0)
 DEFAULT_WEIGHT_COLUMNS = ["Date", "Poids (Kgs)"]
 
 

--- a/tests/test_streamlit_smoke.py
+++ b/tests/test_streamlit_smoke.py
@@ -16,7 +16,7 @@ def _state(at: AppTest) -> None:
     at.session_state["working_data"] = df.copy()
     at.session_state["filtered_data"] = df.copy()
     at.session_state["raw_data"] = df.copy()
-    at.session_state["target_weights"] = (100.0, 95.0, 90.0, 85.0, 90.0)
+    at.session_state["target_weights"] = (100.0, 95.0, 90.0, 85.0, 80.0)
     at.session_state["fast_mode"] = True
 
 
@@ -87,6 +87,6 @@ def test_dashboard_migrates_legacy_four_goals_to_requested_five_goals():
     at.session_state["target_weight"] = 85.0
     at.run(timeout=10)
     assert not at.exception
-    assert at.session_state["target_weights"] == (100.0, 95.0, 90.0, 85.0, 90.0)
-    assert at.session_state["target_weight"] == 90.0
-    assert any("Objectif 5: 90.0 kg" in str(c.value) for c in at.caption)
+    assert at.session_state["target_weights"] == (100.0, 95.0, 90.0, 85.0, 80.0)
+    assert at.session_state["target_weight"] == 80.0
+    assert any("Objectif 5: 80.0 kg" in str(c.value) for c in at.caption)


### PR DESCRIPTION
### Motivation
- Mettre à jour les objectifs affichés dans le graphique pour correspondre aux valeurs demandées : 100, 95, 90, 85 et 80 kg en tant qu'Objectif 5. 
- Aligner la valeur par défaut applicative du poids objectif final avec le nouvel Objectif 5 pour cohérence UI/analytique.
- Adapter les tests qui vérifient la migration des 4 objectifs vers 5 pour refléter la nouvelle valeur finale.

### Description
- Change la constante `DEFAULT_TARGETS` dans `app/core/session_state.py` pour `(100.0, 95.0, 90.0, 85.0, 80.0)` afin que les lignes de cible affichées incluent `80.0` comme Objectif 5. 
- Met à jour `AppDefaults.target_weight` dans `app/config.py` de `90.0` à `80.0` pour aligner la valeur par défaut applicative. 
- Modifie `tests/test_streamlit_smoke.py` pour s'attendre à `Objectif 5: 80.0 kg` et pour que la migration des sessions à 4 objectifs produise désormais la séquence incluant `80.0`.
- Aucun changement fonctionnel à la logique de normalisation ou d'affichage des annotations de lignes cibles (la logique `get_target_weights()` et `_add_target_lines()` reste inchangée).

### Testing
- `python -m py_compile app/core/session_state.py app/config.py tests/test_streamlit_smoke.py` a réussi sans erreur de syntaxe. 
- Exécution de `pytest tests/test_streamlit_smoke.py -q` bloquée par une dépendance manquante (`ModuleNotFoundError: No module named 'numpy'`). 
- Tentative d'installation des dépendances via `python -m pip install -r requirements.txt` bloquée par le proxy/index (`Tunnel connection failed: 403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19748b4bf48329aa8ff7dbf96bd614)