### PR TITLE
Change default final target to 80kg and migrate legacy target sets

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -32,7 +32,7 @@ class AppDefaults:
     """Valeurs par défaut modifiables via l'UI."""
 
     height_cm: int = 182
-    target_weight: float = 90.0
+    target_weight: float = 80.0
     confidence_level: float = 0.9
     duplicate_strategy: str = "garder_la_derniere"
     default_model: str = "ridge"

--- a/app/core/session_state.py
+++ b/app/core/session_state.py
@@ -12,7 +12,12 @@ import streamlit as st
 from app.config import ALL_COLUMNS
 
 
-DEFAULT_TARGETS = (100.0, 95.0, 90.0, 85.0, 90.0)
+DEFAULT_TARGETS = (100.0, 95.0, 90.0, 85.0, 80.0)
+LEGACY_DEFAULT_TARGETS = (
+    (95.0, 90.0, 85.0, 80.0),
+    (100.0, 95.0, 90.0, 85.0),
+    (100.0, 95.0, 90.0, 85.0, 90.0),
+)
 DEFAULT_WEIGHT_COLUMNS = ["Date", "Poids (Kgs)"]
 
 
@@ -20,14 +25,37 @@ def _empty_df() -> pd.DataFrame:
     return pd.DataFrame(columns=list(ALL_COLUMNS))
 
 
+def _numeric_targets(values: list[Any]) -> list[float]:
+    numeric_values: list[float] = []
+    for candidate in values:
+        try:
+            numeric = float(candidate)
+        except (TypeError, ValueError):
+            break
+        if not math.isfinite(numeric):
+            break
+        numeric_values.append(numeric)
+    return numeric_values
+
+
+def _matches_targets(values: list[float], targets: tuple[float, ...]) -> bool:
+    return len(values) == len(targets) and all(
+        round(value, 3) == round(target, 3) for value, target in zip(values, targets, strict=True)
+    )
+
+
 def normalise_target_weights(target_weights: Any = None) -> tuple[float, float, float, float, float]:
-    """Return exactly five numeric targets, padding legacy sessions with defaults."""
+    """Return exactly five numeric targets, migrating old default objective sets."""
     if target_weights is None or isinstance(target_weights, (str, bytes)):
         values: list[Any] = []
     elif isinstance(target_weights, Iterable):
         values = list(target_weights)
     else:
         values = [target_weights]
+
+    numeric_values = _numeric_targets(values)
+    if any(_matches_targets(numeric_values, legacy) for legacy in LEGACY_DEFAULT_TARGETS):
+        return DEFAULT_TARGETS
 
     normalised: list[float] = []
     for idx, default in enumerate(DEFAULT_TARGETS):

--- a/tests/test_streamlit_smoke.py
+++ b/tests/test_streamlit_smoke.py
@@ -16,7 +16,7 @@ def _state(at: AppTest) -> None:
     at.session_state["working_data"] = df.copy()
     at.session_state["filtered_data"] = df.copy()
     at.session_state["raw_data"] = df.copy()
-    at.session_state["target_weights"] = (100.0, 95.0, 90.0, 85.0, 90.0)
+    at.session_state["target_weights"] = (100.0, 95.0, 90.0, 85.0, 80.0)
     at.session_state["fast_mode"] = True
 
 
@@ -83,10 +83,11 @@ def test_settings_exposes_five_goals():
 def test_dashboard_migrates_legacy_four_goals_to_requested_five_goals():
     at = AppTest.from_file("app/pages/Dashboard.py")
     _state(at)
-    at.session_state["target_weights"] = (100.0, 95.0, 90.0, 85.0)
-    at.session_state["target_weight"] = 85.0
+    at.session_state["target_weights"] = (95.0, 90.0, 85.0, 80.0)
+    at.session_state["target_weight"] = 80.0
     at.run(timeout=10)
     assert not at.exception
-    assert at.session_state["target_weights"] == (100.0, 95.0, 90.0, 85.0, 90.0)
-    assert at.session_state["target_weight"] == 90.0
-    assert any("Objectif 5: 90.0 kg" in str(c.value) for c in at.caption)
+    assert at.session_state["target_weights"] == (100.0, 95.0, 90.0, 85.0, 80.0)
+    assert at.session_state["target_weight"] == 80.0
+    assert any("Objectif 1: 100.0 kg" in str(c.value) for c in at.caption)
+    assert any("Objectif 5: 80.0 kg" in str(c.value) for c in at.caption)


### PR DESCRIPTION
### Motivation

- Align the app default objectives to a new final target of `80.0` kg and ensure older stored goal sets are migrated to the new five-goal format.

### Description

- Update default values in `AppDefaults` and session defaults so the default final target is `80.0` kg (`app/config.py` and `app/core/session_state.py`).
- Add legacy migration support by introducing `LEGACY_DEFAULT_TARGETS` and helper functions `_numeric_targets` and `_matches_targets`, and update `normalise_target_weights` to detect and migrate legacy four-/other-goal sets to the current five-goal `DEFAULT_TARGETS` (`app/core/session_state.py`).
- Ensure `get_target_weights` persists the normalized five-target tuple and sets `session_state['target_weight']` to the final goal value (`app/core/session_state.py`).
- Update tests to reflect the new default final target and updated migration behavior (`tests/test_streamlit_smoke.py`).

### Testing

- Ran the smoke tests in `tests/test_streamlit_smoke.py` with `pytest` and Streamlit `AppTest`; all tests in that file passed.
- Verified the legacy migration test now converts a four-goal `(95.0, 90.0, 85.0, 80.0)` input into the five-goal `DEFAULT_TARGETS` and that UI captions reflect the expected objectives.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19748b4bf48329aa8ff7dbf96bd614)