### PR TITLE
Extract target weight helpers to app.core.targets and update imports

### DIFF
--- a/app/core/session_state.py
+++ b/app/core/session_state.py
@@ -2,53 +2,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-import math
-from typing import Any
-
 import pandas as pd
 import streamlit as st
 
 from app.config import ALL_COLUMNS
+from app.core.targets import DEFAULT_TARGETS, get_target_weights, normalise_target_weights
 
-
-DEFAULT_TARGETS = (100.0, 95.0, 90.0, 85.0, 80.0)
 DEFAULT_WEIGHT_COLUMNS = ["Date", "Poids (Kgs)"]
 
 
 def _empty_df() -> pd.DataFrame:
     return pd.DataFrame(columns=list(ALL_COLUMNS))
-
-
-def normalise_target_weights(target_weights: Any = None) -> tuple[float, float, float, float, float]:
-    """Return exactly five numeric targets, padding legacy sessions with defaults."""
-    if target_weights is None or isinstance(target_weights, (str, bytes)):
-        values: list[Any] = []
-    elif isinstance(target_weights, Iterable):
-        values = list(target_weights)
-    else:
-        values = [target_weights]
-
-    normalised: list[float] = []
-    for idx, default in enumerate(DEFAULT_TARGETS):
-        candidate = values[idx] if idx < len(values) else default
-        try:
-            numeric = float(candidate)
-        except (TypeError, ValueError):
-            numeric = default
-        if not math.isfinite(numeric):
-            numeric = default
-        normalised.append(numeric)
-
-    return tuple(normalised)  # type: ignore[return-value]
-
-
-def get_target_weights() -> tuple[float, float, float, float, float]:
-    """Read, migrate and persist the five configured target weights."""
-    targets = normalise_target_weights(st.session_state.get("target_weights"))
-    st.session_state["target_weights"] = targets
-    st.session_state["target_weight"] = float(targets[-1])
-    return targets
 
 
 def get_filtered_or_working_data() -> pd.DataFrame:

--- a/app/core/targets.py
+++ b/app/core/targets.py
@@ -1,0 +1,43 @@
+"""Helpers for user weight targets stored in Streamlit session state."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+import math
+from typing import Any
+
+import streamlit as st
+
+
+DEFAULT_TARGETS = (100.0, 95.0, 90.0, 85.0, 80.0)
+
+
+def normalise_target_weights(target_weights: Any = None) -> tuple[float, float, float, float, float]:
+    """Return exactly five finite numeric targets, padding legacy sessions with defaults."""
+    if target_weights is None or isinstance(target_weights, (str, bytes)):
+        values: list[Any] = []
+    elif isinstance(target_weights, Iterable):
+        values = list(target_weights)
+    else:
+        values = [target_weights]
+
+    normalised: list[float] = []
+    for idx, default in enumerate(DEFAULT_TARGETS):
+        candidate = values[idx] if idx < len(values) else default
+        try:
+            numeric = float(candidate)
+        except (TypeError, ValueError):
+            numeric = default
+        if not math.isfinite(numeric):
+            numeric = default
+        normalised.append(numeric)
+
+    return tuple(normalised)  # type: ignore[return-value]
+
+
+def get_target_weights() -> tuple[float, float, float, float, float]:
+    """Read, migrate and persist the five configured target weights."""
+    targets = normalise_target_weights(st.session_state.get("target_weights"))
+    st.session_state["target_weights"] = targets
+    st.session_state["target_weight"] = float(targets[-1])
+    return targets

--- a/app/pages/Dashboard.py
+++ b/app/pages/Dashboard.py
@@ -23,7 +23,8 @@ from app.core.analytics import (
 )
 from app.core.data import data_quality_report
 from app.core.insights import detect_plateau
-from app.core.session_state import get_filtered_or_working_data, get_target_weights
+from app.core.session_state import get_filtered_or_working_data
+from app.core.targets import get_target_weights
 from app.ui.components import alert_banner, confidence_badge, empty_state, help_box, kpi_card
 
 

--- a/app/pages/Predictions.py
+++ b/app/pages/Predictions.py
@@ -17,7 +17,8 @@ from app.core.evaluation import evaluate_baselines
 from app.core.features import build_features
 from app.core.forecasting import forecast_with_ml, forecast_with_sarimax
 from app.core.insights import estimate_target_eta
-from app.core.session_state import get_filtered_or_working_data, get_target_weights
+from app.core.session_state import get_filtered_or_working_data
+from app.core.targets import get_target_weights
 from app.ui.components import alert_banner, empty_state, kpi_card
 
 warnings.filterwarnings("ignore")

--- a/app/pages/Settings.py
+++ b/app/pages/Settings.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import streamlit as st
 
 from app.config import AppDefaults, DUPLICATE_STRATEGIES
-from app.core.session_state import get_target_weights, normalise_target_weights
+from app.core.targets import get_target_weights, normalise_target_weights
 
 
 def main() -> None:


### PR DESCRIPTION
### Motivation
- Simplify and centralise target weight logic by moving defaults and helper functions out of the generic session-state module to avoid import coupling and reduce page import errors.
- Prevent `ImportError` raised when `app/pages/Settings.py` tried to import target helpers from `session_state` by providing a dedicated module for those helpers.

### Description
- Added `app/core/targets.py` containing `DEFAULT_TARGETS`, `normalise_target_weights()` and `get_target_weights()` to encapsulate target-weight helpers.
- Updated `app/core/session_state.py` to import `DEFAULT_TARGETS`, `get_target_weights` and `normalise_target_weights` from `app.core.targets` and keep using them for session default setup.
- Updated page modules `app/pages/Settings.py`, `app/pages/Dashboard.py` and `app/pages/Predictions.py` to import `get_target_weights`/`normalise_target_weights` from `app.core.targets` and left other `session_state` usages intact.

### Testing
- Ran `python -m compileall -q app tests` which completed successfully.
- Ran local checks (`git diff --check`) and static changes validation which passed without whitespace errors.
- Attempted `pytest -q` but the test run could not complete in this environment because `numpy` is not installed and dependency installation failed due to package index access restrictions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19767bf0388329a2c48e6577f3c267)