### PR TITLE
Fix Settings target import and update weight objectives

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -32,7 +32,7 @@ class AppDefaults:
     """Valeurs par défaut modifiables via l'UI."""
 
     height_cm: int = 182
-    target_weight: float = 80.0
+    target_weight: float = 89.0
     confidence_level: float = 0.9
     duplicate_strategy: str = "garder_la_derniere"
     default_model: str = "ridge"

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core domain helpers for the Suivi Streamlit application."""

--- a/app/core/targets.py
+++ b/app/core/targets.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, MutableMapping
 import math
 from typing import Any
 
-import streamlit as st
 
-
-DEFAULT_TARGETS = (100.0, 95.0, 90.0, 85.0, 80.0)
+DEFAULT_TARGETS = (100.0, 95.0, 90.0, 85.0, 89.0)
+LEGACY_DEFAULT_TARGETS = (100.0, 95.0, 90.0, 85.0, 80.0)
 
 
 def normalise_target_weights(target_weights: Any = None) -> tuple[float, float, float, float, float]:
@@ -32,12 +31,22 @@ def normalise_target_weights(target_weights: Any = None) -> tuple[float, float, 
             numeric = default
         normalised.append(numeric)
 
-    return tuple(normalised)  # type: ignore[return-value]
+    targets = tuple(normalised)
+    if targets == LEGACY_DEFAULT_TARGETS:
+        return DEFAULT_TARGETS
+    return targets  # type: ignore[return-value]
+
+
+def _session_state() -> MutableMapping[str, Any]:
+    import streamlit as st
+
+    return st.session_state
 
 
 def get_target_weights() -> tuple[float, float, float, float, float]:
     """Read, migrate and persist the five configured target weights."""
-    targets = normalise_target_weights(st.session_state.get("target_weights"))
-    st.session_state["target_weights"] = targets
-    st.session_state["target_weight"] = float(targets[-1])
+    session_state = _session_state()
+    targets = normalise_target_weights(session_state.get("target_weights"))
+    session_state["target_weights"] = targets
+    session_state["target_weight"] = float(targets[-1])
     return targets

--- a/tests/test_streamlit_smoke.py
+++ b/tests/test_streamlit_smoke.py
@@ -16,7 +16,7 @@ def _state(at: AppTest) -> None:
     at.session_state["working_data"] = df.copy()
     at.session_state["filtered_data"] = df.copy()
     at.session_state["raw_data"] = df.copy()
-    at.session_state["target_weights"] = (100.0, 95.0, 90.0, 85.0, 80.0)
+    at.session_state["target_weights"] = (100.0, 95.0, 90.0, 85.0, 89.0)
     at.session_state["fast_mode"] = True
 
 
@@ -87,6 +87,6 @@ def test_dashboard_migrates_legacy_four_goals_to_requested_five_goals():
     at.session_state["target_weight"] = 85.0
     at.run(timeout=10)
     assert not at.exception
-    assert at.session_state["target_weights"] == (100.0, 95.0, 90.0, 85.0, 80.0)
-    assert at.session_state["target_weight"] == 80.0
-    assert any("Objectif 5: 80.0 kg" in str(c.value) for c in at.caption)
+    assert at.session_state["target_weights"] == (100.0, 95.0, 90.0, 85.0, 89.0)
+    assert at.session_state["target_weight"] == 89.0
+    assert any("Objectif 5: 89.0 kg" in str(c.value) for c in at.caption)


### PR DESCRIPTION
### Motivation
- Avoid ImportError on the Settings page by preventing `app.core.targets` from importing Streamlit at module import time and ensure the app can read/write target weights reliably.
- Ensure the Dashboard weight evolution graph shows the requested five objectives (including the updated final objective at 89 kg) and migrate legacy sessions that used the old default.

### Description
- Add `app/core/__init__.py` so `app.core` is an explicit package.
- Update `app/core/targets.py` to lazily access `st.session_state` via a `_session_state()` helper, change `DEFAULT_TARGETS` to `(100.0, 95.0, 90.0, 85.0, 89.0)`, add `LEGACY_DEFAULT_TARGETS` and migrate the legacy `(100,95,90,85,80)` to the new default in `normalise_target_weights`.
- Update `AppDefaults.target_weight` in `app/config.py` from `80.0` to `89.0` to keep app defaults consistent.
- Adjust `tests/test_streamlit_smoke.py` expectations to reflect the new final target of `89.0 kg`.

### Testing
- `python -m compileall -q app tests` completed successfully.
- Executed runtime assertions inside the created venv to validate `DEFAULT_TARGETS` and that `normalise_target_weights` migrates legacy four-goal tuples to the new five-goal default, and those checks passed.
- Full `pytest` could not be exercised: running tests in the base Python failed due to missing scientific dependencies, and dependency installation in the environment was blocked by a network/proxy restriction so `pytest` was not available in the venv.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1978e3d9a48329a91bf4132afba919)