### PR TITLE
Fix target helper import and show five target lines in Dashboard

### DIFF
--- a/app/core/session_state.py
+++ b/app/core/session_state.py
@@ -29,7 +29,7 @@ def ensure_session_defaults() -> None:
     st.session_state.setdefault("filtered_data", _empty_df())
 
     st.session_state.setdefault("target_weights", DEFAULT_TARGETS)
-    get_target_weights()
+    get_target_weights(st.session_state)
     st.session_state.setdefault("ma_type", "Simple")
     st.session_state.setdefault("window_size", 7)
     st.session_state.setdefault("theme", "plotly")

--- a/app/core/targets.py
+++ b/app/core/targets.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, MutableMapping
 import math
 from typing import Any
 
-import streamlit as st
-
 
 DEFAULT_TARGETS = (100.0, 95.0, 90.0, 85.0, 80.0)
+TARGET_COUNT = len(DEFAULT_TARGETS)
 
 
 def normalise_target_weights(target_weights: Any = None) -> tuple[float, float, float, float, float]:
@@ -35,9 +34,19 @@ def normalise_target_weights(target_weights: Any = None) -> tuple[float, float, 
     return tuple(normalised)  # type: ignore[return-value]
 
 
-def get_target_weights() -> tuple[float, float, float, float, float]:
-    """Read, migrate and persist the five configured target weights."""
-    targets = normalise_target_weights(st.session_state.get("target_weights"))
-    st.session_state["target_weights"] = targets
-    st.session_state["target_weight"] = float(targets[-1])
+def get_target_weights(session_state: MutableMapping[str, Any] | None = None) -> tuple[float, float, float, float, float]:
+    """Read, migrate and persist the five configured target weights.
+
+    ``streamlit`` is imported lazily so importing this pure helper module cannot
+    fail while Streamlit is initialising a page.  Passing ``session_state`` keeps
+    the function testable and lets pages reuse the same migration logic.
+    """
+    if session_state is None:
+        import streamlit as st
+
+        session_state = st.session_state
+
+    targets = normalise_target_weights(session_state.get("target_weights"))
+    session_state["target_weights"] = targets
+    session_state["target_weight"] = float(targets[-1])
     return targets

--- a/app/pages/Dashboard.py
+++ b/app/pages/Dashboard.py
@@ -24,7 +24,7 @@ from app.core.analytics import (
 from app.core.data import data_quality_report
 from app.core.insights import detect_plateau
 from app.core.session_state import get_filtered_or_working_data
-from app.core.targets import get_target_weights
+from app.core.targets import get_target_weights, normalise_target_weights
 from app.ui.components import alert_banner, confidence_badge, empty_state, help_box, kpi_card
 
 
@@ -51,18 +51,49 @@ def _target_annotation_shift(targets: tuple[float, ...], index: int) -> int:
     return duplicate_position * 18
 
 
-def _add_target_lines(fig: go.Figure, targets: tuple[float, ...], label_prefix: str = "Objectif") -> None:
-    """Draw target lines with readable labels, including duplicated values."""
+def _add_target_lines(
+    fig: go.Figure,
+    targets: tuple[float, ...],
+    label_prefix: str = "Objectif",
+    x_values: pd.Series | pd.Index | None = None,
+) -> None:
+    """Draw the five target lines with readable labels and legend entries."""
+    targets = normalise_target_weights(targets)
     colors = ("#2E7BCF", "#27AE60", "#F39C12", "#8E44AD", "#E74C3C")
+    x_range = None
+    if x_values is not None and len(x_values) > 0:
+        x_range = [x_values.min(), x_values.max()]
+
     for idx, target in enumerate(targets, start=1):
-        fig.add_hline(
-            y=float(target),
-            line_dash="dash",
-            line_color=colors[(idx - 1) % len(colors)],
-            annotation_text=f"{label_prefix} {idx}: {float(target):.1f} kg",
-            annotation_position="top right",
-            annotation_yshift=_target_annotation_shift(targets, idx - 1),
-        )
+        color = colors[(idx - 1) % len(colors)]
+        label = f"{label_prefix} {idx}: {float(target):.1f} kg"
+        if x_range is not None:
+            fig.add_scatter(
+                x=x_range,
+                y=[float(target), float(target)],
+                mode="lines",
+                name=label,
+                line=dict(color=color, dash="dash", width=1.5),
+                hovertemplate=f"{label}<extra></extra>",
+            )
+            fig.add_annotation(
+                x=x_range[-1],
+                y=float(target),
+                text=label,
+                showarrow=False,
+                xanchor="left",
+                yshift=_target_annotation_shift(targets, idx - 1),
+                font=dict(color=color, size=11),
+            )
+        else:
+            fig.add_hline(
+                y=float(target),
+                line_dash="dash",
+                line_color=color,
+                annotation_text=label,
+                annotation_position="top right",
+                annotation_yshift=_target_annotation_shift(targets, idx - 1),
+            )
 
 
 def _targets_caption(targets: tuple[float, ...]) -> str:
@@ -101,7 +132,7 @@ def main() -> None:
 
     height_m = st.session_state.get("height_m", 1.82)
     imc = current / (height_m**2)
-    targets = get_target_weights()
+    targets = get_target_weights(st.session_state)
     target_weight = float(targets[-1])
 
     # ── Bannière période d'effort (A1) ──────────────────────────────────
@@ -271,7 +302,7 @@ def main() -> None:
                     line=dict(color="#E74C3C", width=2.5))
     fig.add_hline(y=float(df["Poids (Kgs)"].mean()), line_dash="dot", annotation_text="Moyenne globale")
 
-    _add_target_lines(fig, targets)
+    _add_target_lines(fig, targets, x_values=df["Date"])
 
     # AN1: Trajectoire cible depuis début de l'effort (pente cible = -2 kg/semaine)
     if has_effort_period:
@@ -326,7 +357,7 @@ def main() -> None:
         for col, color in colors.items():
             if col in df_ma.columns:
                 fig_ma.add_scatter(x=df_ma["Date"], y=df_ma[col], mode="lines", name=labels.get(col, col), line=dict(color=color, width=2))
-        _add_target_lines(fig_ma, targets, label_prefix="Obj.")
+        _add_target_lines(fig_ma, targets, label_prefix="Obj.", x_values=df_ma["Date"])
         fig_ma.update_layout(title="Moyennes mobiles (glissantes sur N mesures consécutives)", hovermode="x unified")
         st.plotly_chart(fig_ma, use_container_width=True)
         st.caption("ℹ️ Les moyennes mobiles glissent sur N mesures consécutives (et non sur N jours calendaires).")

--- a/app/pages/Predictions.py
+++ b/app/pages/Predictions.py
@@ -154,7 +154,7 @@ def _scenarios_block(df: pd.DataFrame) -> None:
     st.subheader("🔮 Scénarios prospectifs")
     st.caption("Scénarios basés sur des rythmes observés (fenêtres 7/14/30j), à interpréter comme guidance et non certitude.")
 
-    target_weight = float(get_target_weights()[-1])
+    target_weight = float(get_target_weights(st.session_state)[-1])
     scenarios = prospective_scenarios(df, target_weight)
 
     if not scenarios:
@@ -235,7 +235,7 @@ def main() -> None:
 
     # ── ETA objectif amélioré (existant + enrichi) ──────────────────────
     st.markdown("---")
-    target_weight = float(get_target_weights()[-1])
+    target_weight = float(get_target_weights(st.session_state)[-1])
 
     # QW3: Utiliser la période d'effort pour l'ETA
     from app.core.analytics import detect_current_effort

--- a/app/pages/Settings.py
+++ b/app/pages/Settings.py
@@ -11,7 +11,7 @@ def main() -> None:
     defaults = AppDefaults()
 
     with st.form("settings_form"):
-        padded_goals = get_target_weights()
+        padded_goals = get_target_weights(st.session_state)
         st.number_input(
             "Poids objectif final (kg)",
             value=float(padded_goals[-1]),


### PR DESCRIPTION
### Motivation
- Éviter l'ImportError lors du chargement des pages Streamlit en retirant l'import eager de `streamlit` du helper des objectifs et en rendant la migration des objectifs testable et déterministe.
- Rendre visibles et explicites les 5 objectifs attendus (100, 95, 90, 85, 80) sur le graphique d'évolution du poids afin que les 5 lignes s'affichent correctement.

### Description
- Retiré l'import direct de `streamlit` d'`app/core/targets.py` et rendu `get_target_weights()` acceptant un `session_state` optionnel, avec fallback lazy sur `st.session_state` si absent.
- Conservé et utilisé `normalise_target_weights()` pour garantir exactement cinq objectifs (par défaut `(100.0, 95.0, 90.0, 85.0, 80.0)`), et propagé la migration dans `st.session_state` via la nouvelle API.
- Mis à jour les appels dans `app/pages/Settings.py`, `app/pages/Dashboard.py`, `app/pages/Predictions.py` et `app/core/session_state.py` pour appeler `get_target_weights(st.session_state)` afin d'éviter les effets de bord à l'import.
- Amélioré `_add_target_lines()` dans `app/pages/Dashboard.py` pour normaliser les cibles à 5 valeurs, accepter une plage `x_values` et tracer chaque objectif comme une vraie trace Plotly (avec légende + annotation) afin que les 5 objectifs soient visibles sur les graphiques principaux et multi-MA.

### Testing
- Exécuté un test ciblé via `python - <<'PY' ... PY` qui vérifie `DEFAULT_TARGETS`, `normalise_target_weights()` et `get_target_weights(state)`, et il a réussi (`target helper ok`).
- Validation de syntaxe via `python -m py_compile` sur les modules modifiés, et la compilation a réussi sans erreurs.
- Tentative d'exécution de la suite `pytest` a échoué car l'environnement local n'inclut pas `numpy` (ModuleNotFoundError) ; les tests unitaires n'ont pas pu être lancés.
- Tentative d'installation des dépendances via `pip install -r requirements.txt` a échoué pour raisons d'accès réseau (PyPI tunnel 403), empêchant l'exécution complète des tests d'intégration/streamlit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1979f8d9908329baa9e0b18d352d8e)