### PR TITLE
Centralise and harden target-weight helpers; migrate legacy 4-goal sessions

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, MutableMapping
 from dataclasses import dataclass
-import math
-from typing import Any, Final
+from typing import Final
 
 DATA_URL: Final[str] = "https://docs.google.com/spreadsheets/d/1qPhLKvm4BREErQrm0L38DcZFG4a-K0msSzARVIG_T_U/export?format=csv"
 REQUIRED_COLUMNS: Final[tuple[str, ...]] = ("Date", "Poids (Kgs)")
@@ -21,57 +19,6 @@ OPTIONAL_COLUMNS: Final[tuple[str, ...]] = (
     "Condition de mesure",
 )
 ALL_COLUMNS: Final[tuple[str, ...]] = REQUIRED_COLUMNS + OPTIONAL_COLUMNS
-
-
-DEFAULT_TARGETS: Final[tuple[float, float, float, float, float]] = (100.0, 95.0, 90.0, 85.0, 80.0)
-LEGACY_FOUR_TARGETS: Final[tuple[float, float, float, float]] = DEFAULT_TARGETS[1:]
-TARGET_COUNT: Final[int] = len(DEFAULT_TARGETS)
-
-
-def _as_finite_float(value: Any, default: float) -> float:
-    try:
-        numeric = float(value)
-    except (TypeError, ValueError):
-        return default
-    return numeric if math.isfinite(numeric) else default
-
-
-def normalise_target_weights(target_weights: Any = None) -> tuple[float, float, float, float, float]:
-    """Return the five configured weight targets, migrating legacy four-goal sessions."""
-    if target_weights is None or isinstance(target_weights, (str, bytes)):
-        values: list[Any] = []
-    elif isinstance(target_weights, Iterable):
-        values = list(target_weights)
-    else:
-        values = [target_weights]
-
-    parsed_values = [_as_finite_float(value, float("nan")) for value in values]
-    finite_values = [value for value in parsed_values if math.isfinite(value)]
-
-    # Older deployed sessions stored only 95/90/85/80.  Prepend the new 100 kg
-    # objective instead of padding at the end, otherwise the graph still starts
-    # at 95 kg and appears unchanged to existing users.
-    rounded_legacy = tuple(round(value, 3) for value in LEGACY_FOUR_TARGETS)
-    rounded_values = tuple(round(value, 3) for value in finite_values)
-    legacy_with_duplicated_final = rounded_legacy + (round(DEFAULT_TARGETS[-1], 3),)
-    if rounded_values == rounded_legacy or rounded_values[:TARGET_COUNT] == legacy_with_duplicated_final:
-        return DEFAULT_TARGETS
-
-    normalised: list[float] = []
-    for idx, default in enumerate(DEFAULT_TARGETS):
-        candidate = values[idx] if idx < len(values) else default
-        normalised.append(_as_finite_float(candidate, default))
-
-    return tuple(normalised)  # type: ignore[return-value]
-
-
-def get_target_weights(session_state: MutableMapping[str, Any]) -> tuple[float, float, float, float, float]:
-    """Read, migrate and persist the five configured target weights in session state."""
-    targets = normalise_target_weights(session_state.get("target_weights"))
-    session_state["target_weights"] = targets
-    session_state["target_weight"] = float(targets[-1])
-    return targets
-
 
 DUPLICATE_STRATEGIES: Final[tuple[str, ...]] = (
     "garder_la_derniere",

--- a/app/config.py
+++ b/app/config.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, MutableMapping
 from dataclasses import dataclass
-from typing import Final
+import math
+from typing import Any, Final
 
 DATA_URL: Final[str] = "https://docs.google.com/spreadsheets/d/1qPhLKvm4BREErQrm0L38DcZFG4a-K0msSzARVIG_T_U/export?format=csv"
 REQUIRED_COLUMNS: Final[tuple[str, ...]] = ("Date", "Poids (Kgs)")
@@ -19,6 +21,57 @@ OPTIONAL_COLUMNS: Final[tuple[str, ...]] = (
     "Condition de mesure",
 )
 ALL_COLUMNS: Final[tuple[str, ...]] = REQUIRED_COLUMNS + OPTIONAL_COLUMNS
+
+
+DEFAULT_TARGETS: Final[tuple[float, float, float, float, float]] = (100.0, 95.0, 90.0, 85.0, 80.0)
+LEGACY_FOUR_TARGETS: Final[tuple[float, float, float, float]] = DEFAULT_TARGETS[1:]
+TARGET_COUNT: Final[int] = len(DEFAULT_TARGETS)
+
+
+def _as_finite_float(value: Any, default: float) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return default
+    return numeric if math.isfinite(numeric) else default
+
+
+def normalise_target_weights(target_weights: Any = None) -> tuple[float, float, float, float, float]:
+    """Return the five configured weight targets, migrating legacy four-goal sessions."""
+    if target_weights is None or isinstance(target_weights, (str, bytes)):
+        values: list[Any] = []
+    elif isinstance(target_weights, Iterable):
+        values = list(target_weights)
+    else:
+        values = [target_weights]
+
+    parsed_values = [_as_finite_float(value, float("nan")) for value in values]
+    finite_values = [value for value in parsed_values if math.isfinite(value)]
+
+    # Older deployed sessions stored only 95/90/85/80.  Prepend the new 100 kg
+    # objective instead of padding at the end, otherwise the graph still starts
+    # at 95 kg and appears unchanged to existing users.
+    rounded_legacy = tuple(round(value, 3) for value in LEGACY_FOUR_TARGETS)
+    rounded_values = tuple(round(value, 3) for value in finite_values)
+    legacy_with_duplicated_final = rounded_legacy + (round(DEFAULT_TARGETS[-1], 3),)
+    if rounded_values == rounded_legacy or rounded_values[:TARGET_COUNT] == legacy_with_duplicated_final:
+        return DEFAULT_TARGETS
+
+    normalised: list[float] = []
+    for idx, default in enumerate(DEFAULT_TARGETS):
+        candidate = values[idx] if idx < len(values) else default
+        normalised.append(_as_finite_float(candidate, default))
+
+    return tuple(normalised)  # type: ignore[return-value]
+
+
+def get_target_weights(session_state: MutableMapping[str, Any]) -> tuple[float, float, float, float, float]:
+    """Read, migrate and persist the five configured target weights in session state."""
+    targets = normalise_target_weights(session_state.get("target_weights"))
+    session_state["target_weights"] = targets
+    session_state["target_weight"] = float(targets[-1])
+    return targets
+
 
 DUPLICATE_STRATEGIES: Final[tuple[str, ...]] = (
     "garder_la_derniere",

--- a/app/core/session_state.py
+++ b/app/core/session_state.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import pandas as pd
 import streamlit as st
 
-from app.config import ALL_COLUMNS
-from app.core.targets import DEFAULT_TARGETS, get_target_weights, normalise_target_weights
+from app.config import ALL_COLUMNS, DEFAULT_TARGETS, get_target_weights, normalise_target_weights
 
 DEFAULT_WEIGHT_COLUMNS = ["Date", "Poids (Kgs)"]
 
@@ -29,7 +28,7 @@ def ensure_session_defaults() -> None:
     st.session_state.setdefault("filtered_data", _empty_df())
 
     st.session_state.setdefault("target_weights", DEFAULT_TARGETS)
-    get_target_weights()
+    get_target_weights(st.session_state)
     st.session_state.setdefault("ma_type", "Simple")
     st.session_state.setdefault("window_size", 7)
     st.session_state.setdefault("theme", "plotly")

--- a/app/core/session_state.py
+++ b/app/core/session_state.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import pandas as pd
 import streamlit as st
 
-from app.config import ALL_COLUMNS, DEFAULT_TARGETS, get_target_weights, normalise_target_weights
+from app.config import ALL_COLUMNS
+from app.core.targets import DEFAULT_TARGETS, get_target_weights, normalise_target_weights
 
 DEFAULT_WEIGHT_COLUMNS = ["Date", "Poids (Kgs)"]
 

--- a/app/core/targets.py
+++ b/app/core/targets.py
@@ -1,17 +1,57 @@
-"""Compatibility re-exports for user weight target helpers.
-
-The implementation lives in :mod:`app.config` so Streamlit pages can import the
-helpers from a module they already load, avoiding page-level ImportError when the
-separate ``app.core.targets`` module is stale during deployment.
-"""
+"""Helpers for user weight targets stored in Streamlit session state."""
 
 from __future__ import annotations
 
-from app.config import DEFAULT_TARGETS, TARGET_COUNT, get_target_weights, normalise_target_weights
+from collections.abc import Iterable, MutableMapping
+import math
+from typing import Any
 
-__all__ = [
-    "DEFAULT_TARGETS",
-    "TARGET_COUNT",
-    "get_target_weights",
-    "normalise_target_weights",
-]
+
+DEFAULT_TARGETS = (100.0, 95.0, 90.0, 85.0, 80.0)
+LEGACY_FOUR_TARGETS = DEFAULT_TARGETS[1:]
+TARGET_COUNT = len(DEFAULT_TARGETS)
+
+
+def _as_finite_float(value: Any, default: float) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return default
+    return numeric if math.isfinite(numeric) else default
+
+
+def normalise_target_weights(target_weights: Any = None) -> tuple[float, float, float, float, float]:
+    """Return exactly five finite numeric targets, migrating legacy sessions."""
+    if target_weights is None or isinstance(target_weights, (str, bytes)):
+        values: list[Any] = []
+    elif isinstance(target_weights, Iterable):
+        values = list(target_weights)
+    else:
+        values = [target_weights]
+
+    finite_values = [_as_finite_float(value, float("nan")) for value in values]
+    rounded_values = tuple(round(value, 3) for value in finite_values if math.isfinite(value))
+    rounded_legacy = tuple(round(value, 3) for value in LEGACY_FOUR_TARGETS)
+    legacy_with_duplicated_final = rounded_legacy + (round(DEFAULT_TARGETS[-1], 3),)
+    if rounded_values == rounded_legacy or rounded_values[:TARGET_COUNT] == legacy_with_duplicated_final:
+        return DEFAULT_TARGETS
+
+    normalised: list[float] = []
+    for idx, default in enumerate(DEFAULT_TARGETS):
+        candidate = values[idx] if idx < len(values) else default
+        normalised.append(_as_finite_float(candidate, default))
+
+    return tuple(normalised)  # type: ignore[return-value]
+
+
+def get_target_weights(session_state: MutableMapping[str, Any] | None = None) -> tuple[float, float, float, float, float]:
+    """Read, migrate and persist the five configured target weights."""
+    if session_state is None:
+        import streamlit as st
+
+        session_state = st.session_state
+
+    targets = normalise_target_weights(session_state.get("target_weights"))
+    session_state["target_weights"] = targets
+    session_state["target_weight"] = float(targets[-1])
+    return targets

--- a/app/core/targets.py
+++ b/app/core/targets.py
@@ -1,43 +1,17 @@
-"""Helpers for user weight targets stored in Streamlit session state."""
+"""Compatibility re-exports for user weight target helpers.
+
+The implementation lives in :mod:`app.config` so Streamlit pages can import the
+helpers from a module they already load, avoiding page-level ImportError when the
+separate ``app.core.targets`` module is stale during deployment.
+"""
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-import math
-from typing import Any
+from app.config import DEFAULT_TARGETS, TARGET_COUNT, get_target_weights, normalise_target_weights
 
-import streamlit as st
-
-
-DEFAULT_TARGETS = (100.0, 95.0, 90.0, 85.0, 80.0)
-
-
-def normalise_target_weights(target_weights: Any = None) -> tuple[float, float, float, float, float]:
-    """Return exactly five finite numeric targets, padding legacy sessions with defaults."""
-    if target_weights is None or isinstance(target_weights, (str, bytes)):
-        values: list[Any] = []
-    elif isinstance(target_weights, Iterable):
-        values = list(target_weights)
-    else:
-        values = [target_weights]
-
-    normalised: list[float] = []
-    for idx, default in enumerate(DEFAULT_TARGETS):
-        candidate = values[idx] if idx < len(values) else default
-        try:
-            numeric = float(candidate)
-        except (TypeError, ValueError):
-            numeric = default
-        if not math.isfinite(numeric):
-            numeric = default
-        normalised.append(numeric)
-
-    return tuple(normalised)  # type: ignore[return-value]
-
-
-def get_target_weights() -> tuple[float, float, float, float, float]:
-    """Read, migrate and persist the five configured target weights."""
-    targets = normalise_target_weights(st.session_state.get("target_weights"))
-    st.session_state["target_weights"] = targets
-    st.session_state["target_weight"] = float(targets[-1])
-    return targets
+__all__ = [
+    "DEFAULT_TARGETS",
+    "TARGET_COUNT",
+    "get_target_weights",
+    "normalise_target_weights",
+]

--- a/app/pages/Dashboard.py
+++ b/app/pages/Dashboard.py
@@ -5,95 +5,36 @@ import plotly.express as px
 import plotly.graph_objects as go
 import streamlit as st
 
-from app.core.analytics import (
-    analyze_effort_history,
-    compute_trend_ema,
-    detect_current_effort,
-    discipline_score,
-    generate_action_summary,
-    generate_insights_text,
-    multi_rolling_averages,
-    next_milestone,
-    pace_comparison,
-    progression_score,
-    streak_analysis,
-    weight_acceleration,
-    weight_velocity,
-    weight_volatility,
-)
 from app.core.data import data_quality_report
 from app.core.insights import detect_plateau
 from app.core.session_state import get_filtered_or_working_data
-from app.config import get_target_weights, normalise_target_weights
+from app.core.targets import get_target_weights, normalise_target_weights
 from app.ui.components import alert_banner, confidence_badge, empty_state, help_box, kpi_card
-
-
-TARGET_TRAJECTORY_KG_PER_WEEK = -2.0
-TARGET_TRAJECTORY_DAILY_RATE = TARGET_TRAJECTORY_KG_PER_WEEK / 7
-TARGET_TRAJECTORY_LABEL = f"Trajectoire cible ({TARGET_TRAJECTORY_KG_PER_WEEK:g} kg/semaine)"
-TARGET_TRAJECTORY_CHART_KEY = "dashboard-target-trajectory-2kg-week"
 
 
 def _df() -> pd.DataFrame:
     return get_filtered_or_working_data()
 
 
-def _moving_average(series: pd.Series, window: int, ma_type: str) -> pd.Series:
-    if ma_type == "Exponentielle":
-        return series.ewm(span=max(window, 2), adjust=False).mean()
-    return series.rolling(window=window, min_periods=1).mean()
-
-
 def _target_annotation_shift(targets: tuple[float, ...], index: int) -> int:
-    """Offset duplicate target annotations so identical goals remain readable."""
     target = round(float(targets[index]), 3)
     duplicate_position = sum(1 for previous in targets[:index] if round(float(previous), 3) == target)
     return duplicate_position * 18
 
 
-def _add_target_lines(
-    fig: go.Figure,
-    targets: tuple[float, ...],
-    label_prefix: str = "Objectif",
-    x_values: pd.Series | pd.Index | None = None,
-) -> None:
-    """Draw the five target lines with readable labels and legend entries."""
+def _add_target_lines(fig: go.Figure, targets: tuple[float, ...]) -> None:
+    """Draw the five configured target lines on the weight evolution graph."""
     targets = normalise_target_weights(targets)
     colors = ("#2E7BCF", "#27AE60", "#F39C12", "#8E44AD", "#E74C3C")
-    x_range = None
-    if x_values is not None and len(x_values) > 0:
-        x_range = [x_values.min(), x_values.max()]
-
     for idx, target in enumerate(targets, start=1):
-        color = colors[(idx - 1) % len(colors)]
-        label = f"{label_prefix} {idx}: {float(target):.1f} kg"
-        if x_range is not None:
-            fig.add_scatter(
-                x=x_range,
-                y=[float(target), float(target)],
-                mode="lines",
-                name=label,
-                line=dict(color=color, dash="dash", width=1.5),
-                hovertemplate=f"{label}<extra></extra>",
-            )
-            fig.add_annotation(
-                x=x_range[-1],
-                y=float(target),
-                text=label,
-                showarrow=False,
-                xanchor="left",
-                yshift=_target_annotation_shift(targets, idx - 1),
-                font=dict(color=color, size=11),
-            )
-        else:
-            fig.add_hline(
-                y=float(target),
-                line_dash="dash",
-                line_color=color,
-                annotation_text=label,
-                annotation_position="top right",
-                annotation_yshift=_target_annotation_shift(targets, idx - 1),
-            )
+        fig.add_hline(
+            y=float(target),
+            line_dash="dash",
+            line_color=colors[(idx - 1) % len(colors)],
+            annotation_text=f"Objectif {idx}: {float(target):.1f} kg",
+            annotation_position="top right",
+            annotation_yshift=_target_annotation_shift(targets, idx - 1),
+        )
 
 
 def _targets_caption(targets: tuple[float, ...]) -> str:
@@ -108,363 +49,37 @@ def main() -> None:
         empty_state("Aucune donnée disponible. Utilisez Journal ou import CSV.")
         return
 
-    df = df.sort_values("Date").copy()
+    df = df.sort_values("Date")
     current = df["Poids (Kgs)"].iloc[-1]
     prev = df["Poids (Kgs)"].iloc[-2] if len(df) > 1 else current
-    last_date = df["Date"].max()
-
-    # ── Détection période d'effort actuelle (A1/A3) ────────────────────
-    effort = detect_current_effort(df, gap_threshold_days=21)
-    effort_df = effort["effort_df"]
-    effort_start = effort["start_date"]
-    effort_days = effort["days"]
-    effort_measurements = effort["measurements"]
-    has_effort_period = effort["is_subset"] and len(effort_df) >= 2
-    is_startup = effort_days < 7  # C3: phase de démarrage = données fragiles
-
-    # Filtrage par dates calendaires réelles
-    short_data = df[df["Date"] >= last_date - pd.Timedelta(days=7)]["Poids (Kgs)"]
-    short = float(short_data.mean()) if not short_data.empty else current
-    short_n = len(short_data)
-    long_data = df[df["Date"] >= last_date - pd.Timedelta(days=30)]["Poids (Kgs)"]
-    long = float(long_data.mean()) if not long_data.empty else df["Poids (Kgs)"].mean()
-    long_n = len(long_data)
-
-    height_m = st.session_state.get("height_m", 1.82)
-    imc = current / (height_m**2)
+    short = df["Poids (Kgs)"].tail(7).mean()
+    long = df["Poids (Kgs)"].tail(30).mean() if len(df) >= 30 else df["Poids (Kgs)"].mean()
     targets = get_target_weights(st.session_state)
-    target_weight = float(targets[-1])
 
-    # ── Bannière période d'effort (A1) ──────────────────────────────────
-    if has_effort_period:
-        effort_initial = float(effort_df["Poids (Kgs)"].iloc[0])
-        effort_delta = effort_initial - current
-        delta_icon = "📉" if effort_delta > 0 else "📈" if effort_delta < 0 else "➡️"
-        delta_text = f"-{effort_delta:.1f}" if effort_delta > 0 else f"+{abs(effort_delta):.1f}"
-        st.info(
-            f"📅 **Période d'effort actuelle** : depuis le {effort_start.strftime('%d/%m/%Y')} "
-            f"({effort_days} jours, {effort_measurements} mesures) — "
-            f"{delta_icon} **{delta_text} kg** ({effort_initial:.1f} → {current:.1f} kg)"
-        )
-
-    # ── KPIs principaux ─────────────────────────────────────────────────
-    # C4: Poids EMA lissé comme métrique de référence
-    df_ema_kpi = compute_trend_ema(df, span=7)
-    ema_current = float(df_ema_kpi["Tendance_EMA"].iloc[-1])
-    ema_prev = float(df_ema_kpi["Tendance_EMA"].iloc[-2]) if len(df_ema_kpi) > 1 else ema_current
-
-    c1, c2, c3, c4, c5 = st.columns(5)
+    c1, c2, c3, c4 = st.columns(4)
     with c1:
         kpi_card("Poids actuel", f"{current:.2f} kg", f"{current-prev:+.2f}")
     with c2:
-        kpi_card("Tendance (EMA)", f"{ema_current:.2f} kg", f"{ema_current-ema_prev:+.2f}",
-                 help_text="Poids lissé — filtre les fluctuations quotidiennes. C'est votre vrai indicateur.")
+        kpi_card("Tendance 7j", f"{short:.2f} kg")
     with c3:
-        kpi_card("Moy. 30 derniers jours", f"{long:.2f} kg", help_text=f"Basé sur {long_n} mesure(s) des 30 derniers jours calendaires")
+        kpi_card("Tendance longue", f"{long:.2f} kg")
     with c4:
-        kpi_card("IMC", f"{imc:.2f}")
-    with c5:
-        quality = data_quality_report(effort_df if has_effort_period else df)
+        quality = data_quality_report(df)
         kpi_card("Qualité des données", f"{quality['score']}/100")
 
-    # ── KPIs avancés (calculés sur l'effort, pas l'historique global) ──
-    analysis_df = effort_df if has_effort_period else df
-    vel = weight_velocity(analysis_df, windows=(7, 14, 30))
-    disc = discipline_score(analysis_df, window_days=min(effort_days, 30) if effort_days > 0 else 30)
-    prog = progression_score(analysis_df, target_weight)
-    streaks = streak_analysis(analysis_df)
-
-    c6, c7, c8, c9 = st.columns(4)
-    with c6:
-        v7 = vel.get(7)
-        v_display = f"{v7:+.2f} kg/sem" if v7 is not None else "N/A"
-        # C3: Flag fragile si phase de démarrage
-        v_help = "Variation de poids en kg par semaine sur les 7 derniers jours"
-        if is_startup:
-            v_display += " ⚠️"
-            v_help += " — signal fragile (< 7 jours de données)"
-        kpi_card("Vitesse 7j", v_display, help_text=v_help)
-    with c7:
-        kpi_card("Discipline", f"{disc['score']}/100", help_text=f"{disc['interpretation'].title()} — {disc['measured_days']}/{disc['expected_days']} jours mesurés")
-    with c8:
-        confidence_label = prog.get('confidence', 'solide')
-        conf_icon = "⚠️ " if confidence_label == 'fragile' else ""
-        kpi_card("Score global", f"{conf_icon}{prog['score']}/100 ({prog['grade']})",
-                 help_text=f"Score composite. {'Signal fragile (< 7 mesures)' if confidence_label == 'fragile' else 'Signal fiable'}")
-    with c9:
-        streak_icon = "🔥" if streaks["current_type"] == "perte" else "📈" if streaks["current_type"] == "gain" else "➡️"
-        streak_txt = f"{streak_icon} {streaks['current_streak']} mesures en {streaks['current_type']}"
-        kpi_card("Série en cours", streak_txt, help_text=f"Record perte : {streaks['longest_loss']} mesures · Record gain : {streaks['longest_gain']} mesures")
-
-    # ── Barre de progression (recalibrée sur effort) ────────────────────
-    if has_effort_period:
-        effort_initial_weight = float(effort_df["Poids (Kgs)"].iloc[0])
-        if effort_initial_weight > target_weight:
-            total = effort_initial_weight - target_weight
-            progress = ((effort_initial_weight - current) / total * 100) if total > 0 else 0.0
-        else:
-            progress = 100.0
-        progress_label = f"Progression effort actuel vers {target_weight:.1f} kg"
-    else:
-        initial = df["Poids (Kgs)"].iloc[0]
-        final_target = targets[-1]
-        total = initial - final_target
-        progress = ((initial - current) / total * 100) if total > 0 else 0.0
-        progress_label = f"Progression vers l'objectif final ({targets[-1]:.1f} kg)"
-
-    progress = max(0.0, min(100.0, progress))
-    st.progress(progress / 100)
-    st.caption(f"{progress_label}: {progress:.1f}%")
-    st.caption("ℹ️ Les métriques marquées ⚠️ sont informatives, mais restent fragiles en phase de démarrage.")
-
-    # ── Prochain milestone intelligent (AN4 — avec garde-fous C1/C3) ──
-    v14 = vel.get(14)
-    milestone = next_milestone(current, targets, velocity=v14, measurements=effort_measurements)
-    ms_text = f"🎯 **Prochain palier** : {milestone['label']} (reste **{milestone['remaining']:.1f} kg**)"
-    if milestone.get("eta_days") is not None:
-        conf = milestone.get('eta_confidence', '')
-        conf_note = f" (confiance: {conf})" if conf else ""
-        ms_text += f" — ETA: **~{milestone['eta_days']} jours**{conf_note}"
-    elif milestone.get("eta_confidence") == "fragile":
-        ms_text += " — ETA: disponible après 7+ mesures"
-    st.caption(ms_text)
-
-    # ── Signal de tendance cohérent (A5) ────────────────────────────────
-    plateau = detect_plateau(analysis_df, window=14)
-    nb_mesures_plateau = plateau.get("nb_mesures", 0)
-
-    if nb_mesures_plateau >= 3:
-        if plateau["status"] == "plateau probable":
-            alert_banner(f"➡️ Plateau probable détecté ({nb_mesures_plateau} mesures, pente={plateau['slope']:.3f})", "warning")
-        elif plateau["status"] == "baisse active":
-            alert_banner(f"📉 Tendance à la baisse ({nb_mesures_plateau} mesures, pente={plateau['slope']:.3f})", "success")
-        elif "reprise" in plateau["status"]:
-            alert_banner(f"📈 Tendance à la hausse ({nb_mesures_plateau} mesures, pente={plateau['slope']:.3f})", "warning")
-    else:
-        st.caption(f"📊 Signal de tendance : données limitées ({nb_mesures_plateau} mesures sur 14j)")
+    plateau = detect_plateau(df, window=14)
+    if plateau["status"] == "plateau probable":
+        alert_banner("Plateau probable détecté sur 14 jours.", "warning")
 
     confidence = "élevée" if quality["score"] > 80 else "moyenne" if quality["score"] > 60 else "faible"
     confidence_badge("Confiance signal", confidence)
 
-    # ── Alertes intelligentes contextuelles (A9) ────────────────────────
-    _render_smart_alerts(df, analysis_df, streaks, last_date)
-
-    # ── Insight pattern yo-yo historique (AN2 — NOUVEAU) ────────────────
-    history = analyze_effort_history(df)
-    if history.get("insight"):
-        st.warning(history["insight"])
-        if history.get("best_effort"):
-            best = history["best_effort"]
-            st.caption(
-                f"💪 Meilleur effort passé : **-{best['delta']:.1f} kg** en {best['days']} jours "
-                f"({best['start_date'].strftime('%d/%m/%Y')} → {best['end_date'].strftime('%d/%m/%Y')}, {best['measurements']} mesures)"
-            )
-
-    # ── C2: Résumé actionnable Situation / Interprétation / Action ──────
-    st.markdown("---")
-    summary = generate_action_summary(df, target_weight)
-    st.subheader("🧭 Votre résumé")
-    st.markdown(f"📍 **Situation** : {summary['situation']}")
-    st.markdown(f"🔍 **Interprétation** : {summary['interpretation']}")
-    st.markdown(f"▶️ **Action** : {summary['action']}")
-
-    # ── Insights détaillés (dans un expander) ───────────────────────────
-    with st.expander("💡 Insights détaillés", expanded=False):
-        insights = generate_insights_text(df, target_weight)
-        for insight in insights:
-            st.markdown(f"> {insight}")
-
-        # Accélération
-        acc = weight_acceleration(analysis_df)
-        if acc["interpretation"] != "données insuffisantes":
-            st.caption(f"📐 Accélération : {acc['interpretation']}")
-
-        # Comparaison rythme actuel vs nécessaire (A7) — seulement si effort établi
-        if not is_startup:
-            pace = pace_comparison(analysis_df, target_weight)
-            if pace.get("current_pace") is not None:
-                st.caption(f"🏎️ {pace['interpretation']}")
-        else:
-            st.caption("🏎️ Comparaison de rythme : disponible après 7+ jours de suivi.")
-
-    # ── Graphique principal avec MA + EMA + trajectoire cible (AN1 — NOUVEAU) ──
-    st.markdown("---")
-    ma_type = st.session_state.get("ma_type", "Simple")
-    window_size = int(st.session_state.get("window_size", 7))
-    df["Poids_MA"] = _moving_average(df["Poids (Kgs)"], window_size, ma_type)
-
-    df_ema = compute_trend_ema(df, span=window_size)
-
     fig = px.line(df, x="Date", y="Poids (Kgs)", title="Évolution du poids")
-    fig.add_scatter(x=df["Date"], y=df["Poids_MA"], mode="lines", name=f"MM {ma_type} ({window_size}j)",
-                    line=dict(width=1.5, dash="dot"))
-    fig.add_scatter(x=df_ema["Date"], y=df_ema["Tendance_EMA"], mode="lines", name=f"Tendance EMA ({window_size})",
-                    line=dict(color="#E74C3C", width=2.5))
-    fig.add_hline(y=float(df["Poids (Kgs)"].mean()), line_dash="dot", annotation_text="Moyenne globale")
-
-    _add_target_lines(fig, targets, x_values=df["Date"])
-
-    # AN1: Trajectoire cible depuis début de l'effort (pente cible = -2 kg/semaine)
-    if has_effort_period:
-        effort_initial_w = float(effort_df["Poids (Kgs)"].iloc[0])
-        # Tracer sur 180 jours max depuis début effort
-        traj_dates = pd.date_range(effort_start, periods=min(180, max(effort_days * 3, 90)), freq="D")
-        traj_values = [effort_initial_w + TARGET_TRAJECTORY_DAILY_RATE * i for i in range(len(traj_dates))]
-        # Ne pas descendre en dessous de l'objectif final
-        traj_values = [max(v, target_weight) for v in traj_values]
-
-        fig.add_scatter(
-            x=traj_dates,
-            y=traj_values,
-            mode="lines",
-            name=TARGET_TRAJECTORY_LABEL,
-            line=dict(color="#27AE60", width=2, dash="dashdot"),
-            hovertemplate=(
-                "Date: %{x|%d/%m/%Y}<br>"
-                "Poids cible: %{y:.1f} kg<br>"
-                f"Rythme: {TARGET_TRAJECTORY_KG_PER_WEEK:g} kg/semaine<extra></extra>"
-            ),
-        )
-
-        # Corridor ±1 kg
-        traj_upper = [v + 1.0 for v in traj_values]
-        traj_lower = [max(v - 1.0, target_weight) for v in traj_values]
-        fig.add_scatter(x=traj_dates, y=traj_upper, mode="lines",
-                        line=dict(width=0), showlegend=False)
-        fig.add_scatter(x=traj_dates, y=traj_lower, mode="lines",
-                        fill="tonexty", fillcolor="rgba(39,174,96,0.08)",
-                        line=dict(width=0), name="Corridor cible (±1 kg)")
-
-        # Zone effort
-        fig.add_vrect(x0=effort_start, x1=last_date, fillcolor="rgba(39,174,96,0.05)",
-                      annotation_text="Effort actuel", line_width=0)
-
-    st.caption(f"🎯 Trajectoire cible du graphique : **{TARGET_TRAJECTORY_KG_PER_WEEK:g} kg/semaine**.")
+    _add_target_lines(fig, targets)
     st.caption(_targets_caption(targets))
-    st.plotly_chart(fig, use_container_width=True, key=TARGET_TRAJECTORY_CHART_KEY)
-
-    # ── Vue hebdomadaire consolidée (AN3 — NOUVEAU) ─────────────────────
-    with st.expander("📊 Vue hebdomadaire consolidée", expanded=False):
-        _render_weekly_view(df, targets)
-
-    # ── Graphique multi-MA (existant) ───────────────────────────────────
-    with st.expander("📊 Moyennes mobiles multiples (7/14/30 mesures)", expanded=False):
-        df_ma = multi_rolling_averages(df, windows=(7, 14, 30))
-        fig_ma = go.Figure()
-        fig_ma.add_scatter(x=df_ma["Date"], y=df_ma["Poids (Kgs)"], mode="markers", name="Mesures", opacity=0.4, marker=dict(size=4))
-        colors = {"MA_7m": "#2E7BCF", "MA_14m": "#E67E22", "MA_30m": "#27AE60"}
-        labels = {"MA_7m": "MA 7 mesures", "MA_14m": "MA 14 mesures", "MA_30m": "MA 30 mesures"}
-        for col, color in colors.items():
-            if col in df_ma.columns:
-                fig_ma.add_scatter(x=df_ma["Date"], y=df_ma[col], mode="lines", name=labels.get(col, col), line=dict(color=color, width=2))
-        _add_target_lines(fig_ma, targets, label_prefix="Obj.", x_values=df_ma["Date"])
-        fig_ma.update_layout(title="Moyennes mobiles (glissantes sur N mesures consécutives)", hovermode="x unified")
-        st.plotly_chart(fig_ma, use_container_width=True)
-        st.caption("ℹ️ Les moyennes mobiles glissent sur N mesures consécutives (et non sur N jours calendaires).")
-
-    # ── Comparaison hebdo (existant) ────────────────────────────────────
-    wk_data = df[df["Date"] >= last_date - pd.Timedelta(days=7)]["Poids (Kgs)"]
-    prev_wk_data = df[(df["Date"] >= last_date - pd.Timedelta(days=14)) & (df["Date"] < last_date - pd.Timedelta(days=7))]["Poids (Kgs)"]
-    wk = float(wk_data.mean()) if not wk_data.empty else current
-    prev_wk = float(prev_wk_data.mean()) if not prev_wk_data.empty else wk
-    delta_wk = wk - prev_wk
-    st.metric("Comparaison hebdo (7j calendaires)", f"{wk:.2f} kg", f"{delta_wk:+.2f} kg", delta_color="inverse",
-             help=f"Semaine courante: {len(wk_data)} mesure(s) · Semaine précédente: {len(prev_wk_data)} mesure(s)")
-    if len(wk_data) < 3 or len(prev_wk_data) < 3:
-        st.caption("⚠️ Comparaison hebdo prudente: moins de 3 mesures sur au moins une des deux semaines.")
-
-    # ── Volatilité (existant) ───────────────────────────────────────────
-    vol = weight_volatility(analysis_df, window=14)
-    st.caption(f"📊 Volatilité (14 derniers jours) : {vol['interpretation']} (σ={vol['std']:.2f} kg, amplitude={vol['range']:.1f} kg, {vol.get('nb_mesures', '?')} mesures)")
-
-    # ── Distribution et IMC (existant) ──────────────────────────────────
-    with st.expander("Distribution et évolution IMC"):
-        hist = px.histogram(df, x="Poids (Kgs)", nbins=25, title="Distribution du poids")
-        st.plotly_chart(hist, use_container_width=True)
-        df["IMC"] = df["Poids (Kgs)"] / (height_m**2)
-        bmi_line = px.line(df, x="Date", y="IMC", title="Évolution de l'IMC")
-        st.plotly_chart(bmi_line, use_container_width=True)
-
-    # ── Score de progression détaillé (existant) ────────────────────────
-    with st.expander("🏆 Détail du score de progression"):
-        components = prog.get("components", {})
-        if components:
-            comp_cols = st.columns(len(components))
-            for i, (key, val) in enumerate(components.items()):
-                with comp_cols[i]:
-                    st.metric(key.title(), f"{val:.0f}")
+    st.plotly_chart(fig, use_container_width=True)
 
     help_box("Résumé hebdo", "Cette vue est analytique et informative; elle ne remplace pas un avis médical.")
-
-
-def _render_smart_alerts(df: pd.DataFrame, analysis_df: pd.DataFrame, streaks: dict, last_date: pd.Timestamp) -> None:
-    """Alertes intelligentes contextuelles (A9)."""
-    # Alerte : pas de mesure récente
-    days_since_last = (pd.Timestamp.now().normalize() - last_date).days
-    if days_since_last >= 3:
-        alert_banner(f"📏 Dernière mesure il y a {days_since_last} jours. Pensez à vous peser !", "info")
-
-    # Alerte : série de perte en cours
-    if streaks["current_streak"] >= 3 and streaks["current_type"] == "perte":
-        alert_banner(f"🔥 Belle série ! {streaks['current_streak']} mesures consécutives en baisse.", "success")
-
-    # Alerte : nouveau plus bas récent
-    if len(analysis_df) >= 5:
-        recent_min = float(analysis_df["Poids (Kgs)"].tail(3).min())
-        older_min = float(analysis_df["Poids (Kgs)"].iloc[:-3].min()) if len(analysis_df) > 3 else recent_min + 1
-        if recent_min < older_min:
-            alert_banner(f"🎉 Nouveau plus bas atteint : {recent_min:.1f} kg !", "success")
-
-    # Alerte : remontée après série de perte (rassurer)
-    if streaks["current_streak"] >= 1 and streaks["current_type"] == "gain" and streaks["longest_loss"] >= 3:
-        if len(analysis_df) >= 3:
-            alert_banner("📊 Petite remontée après une bonne série — c'est normal, les fluctuations quotidiennes sont naturelles.", "info")
-
-
-def _render_weekly_view(df: pd.DataFrame, targets: tuple) -> None:
-    """Vue hebdomadaire consolidée (AN3)."""
-    data = df.copy()
-    data["week_start"] = data["Date"].dt.to_period("W").apply(lambda x: x.start_time)
-    weekly = data.groupby("week_start").agg(
-        poids_moyen=("Poids (Kgs)", "mean"),
-        poids_min=("Poids (Kgs)", "min"),
-        poids_max=("Poids (Kgs)", "max"),
-        nb_mesures=("Poids (Kgs)", "count"),
-    ).reset_index()
-    weekly = weekly[weekly["nb_mesures"] >= 1]
-    weekly["variation"] = weekly["poids_moyen"].diff()
-
-    if weekly.empty:
-        st.info("Pas assez de données hebdomadaires.")
-        return
-
-    # Limiter aux 26 dernières semaines pour la lisibilité
-    display_weeks = weekly.tail(26)
-
-    # Bar chart des moyennes hebdo
-    colors = ["#27AE60" if v is not None and v < -0.1 else "#E74C3C" if v is not None and v > 0.1 else "#95A5A6"
-              for v in display_weeks["variation"]]
-    fig_wk = go.Figure()
-    fig_wk.add_bar(
-        x=display_weeks["week_start"],
-        y=display_weeks["poids_moyen"],
-        marker_color=colors,
-        text=[f"{w:.1f}" for w in display_weeks["poids_moyen"]],
-        textposition="outside",
-        hovertext=[f"Moy: {row.poids_moyen:.1f} kg | Min: {row.poids_min:.1f} | Max: {row.poids_max:.1f} | {row.nb_mesures} mes."
-                   for _, row in display_weeks.iterrows()],
-        hoverinfo="text",
-    )
-    for idx, target in enumerate(targets, start=1):
-        fig_wk.add_hline(y=float(target), line_dash="dash", annotation_text=f"Obj. {idx}")
-    fig_wk.update_layout(
-        title="Poids moyen par semaine (vert = baisse, rouge = hausse)",
-        yaxis_title="Poids moyen (kg)",
-        showlegend=False,
-        height=400,
-    )
-    st.plotly_chart(fig_wk, use_container_width=True)
-    st.caption("ℹ️ Chaque barre = moyenne des mesures de la semaine. La couleur indique le sens de la variation par rapport à la semaine précédente.")
 
 
 main()

--- a/app/pages/Dashboard.py
+++ b/app/pages/Dashboard.py
@@ -24,7 +24,7 @@ from app.core.analytics import (
 from app.core.data import data_quality_report
 from app.core.insights import detect_plateau
 from app.core.session_state import get_filtered_or_working_data
-from app.core.targets import get_target_weights
+from app.config import get_target_weights, normalise_target_weights
 from app.ui.components import alert_banner, confidence_badge, empty_state, help_box, kpi_card
 
 
@@ -51,18 +51,49 @@ def _target_annotation_shift(targets: tuple[float, ...], index: int) -> int:
     return duplicate_position * 18
 
 
-def _add_target_lines(fig: go.Figure, targets: tuple[float, ...], label_prefix: str = "Objectif") -> None:
-    """Draw target lines with readable labels, including duplicated values."""
+def _add_target_lines(
+    fig: go.Figure,
+    targets: tuple[float, ...],
+    label_prefix: str = "Objectif",
+    x_values: pd.Series | pd.Index | None = None,
+) -> None:
+    """Draw the five target lines with readable labels and legend entries."""
+    targets = normalise_target_weights(targets)
     colors = ("#2E7BCF", "#27AE60", "#F39C12", "#8E44AD", "#E74C3C")
+    x_range = None
+    if x_values is not None and len(x_values) > 0:
+        x_range = [x_values.min(), x_values.max()]
+
     for idx, target in enumerate(targets, start=1):
-        fig.add_hline(
-            y=float(target),
-            line_dash="dash",
-            line_color=colors[(idx - 1) % len(colors)],
-            annotation_text=f"{label_prefix} {idx}: {float(target):.1f} kg",
-            annotation_position="top right",
-            annotation_yshift=_target_annotation_shift(targets, idx - 1),
-        )
+        color = colors[(idx - 1) % len(colors)]
+        label = f"{label_prefix} {idx}: {float(target):.1f} kg"
+        if x_range is not None:
+            fig.add_scatter(
+                x=x_range,
+                y=[float(target), float(target)],
+                mode="lines",
+                name=label,
+                line=dict(color=color, dash="dash", width=1.5),
+                hovertemplate=f"{label}<extra></extra>",
+            )
+            fig.add_annotation(
+                x=x_range[-1],
+                y=float(target),
+                text=label,
+                showarrow=False,
+                xanchor="left",
+                yshift=_target_annotation_shift(targets, idx - 1),
+                font=dict(color=color, size=11),
+            )
+        else:
+            fig.add_hline(
+                y=float(target),
+                line_dash="dash",
+                line_color=color,
+                annotation_text=label,
+                annotation_position="top right",
+                annotation_yshift=_target_annotation_shift(targets, idx - 1),
+            )
 
 
 def _targets_caption(targets: tuple[float, ...]) -> str:
@@ -101,7 +132,7 @@ def main() -> None:
 
     height_m = st.session_state.get("height_m", 1.82)
     imc = current / (height_m**2)
-    targets = get_target_weights()
+    targets = get_target_weights(st.session_state)
     target_weight = float(targets[-1])
 
     # ── Bannière période d'effort (A1) ──────────────────────────────────
@@ -271,7 +302,7 @@ def main() -> None:
                     line=dict(color="#E74C3C", width=2.5))
     fig.add_hline(y=float(df["Poids (Kgs)"].mean()), line_dash="dot", annotation_text="Moyenne globale")
 
-    _add_target_lines(fig, targets)
+    _add_target_lines(fig, targets, x_values=df["Date"])
 
     # AN1: Trajectoire cible depuis début de l'effort (pente cible = -2 kg/semaine)
     if has_effort_period:
@@ -326,7 +357,7 @@ def main() -> None:
         for col, color in colors.items():
             if col in df_ma.columns:
                 fig_ma.add_scatter(x=df_ma["Date"], y=df_ma[col], mode="lines", name=labels.get(col, col), line=dict(color=color, width=2))
-        _add_target_lines(fig_ma, targets, label_prefix="Obj.")
+        _add_target_lines(fig_ma, targets, label_prefix="Obj.", x_values=df_ma["Date"])
         fig_ma.update_layout(title="Moyennes mobiles (glissantes sur N mesures consécutives)", hovermode="x unified")
         st.plotly_chart(fig_ma, use_container_width=True)
         st.caption("ℹ️ Les moyennes mobiles glissent sur N mesures consécutives (et non sur N jours calendaires).")

--- a/app/pages/Predictions.py
+++ b/app/pages/Predictions.py
@@ -18,7 +18,7 @@ from app.core.features import build_features
 from app.core.forecasting import forecast_with_ml, forecast_with_sarimax
 from app.core.insights import estimate_target_eta
 from app.core.session_state import get_filtered_or_working_data
-from app.config import get_target_weights
+from app.core.targets import get_target_weights
 from app.ui.components import alert_banner, empty_state, kpi_card
 
 warnings.filterwarnings("ignore")

--- a/app/pages/Predictions.py
+++ b/app/pages/Predictions.py
@@ -18,7 +18,7 @@ from app.core.features import build_features
 from app.core.forecasting import forecast_with_ml, forecast_with_sarimax
 from app.core.insights import estimate_target_eta
 from app.core.session_state import get_filtered_or_working_data
-from app.core.targets import get_target_weights
+from app.config import get_target_weights
 from app.ui.components import alert_banner, empty_state, kpi_card
 
 warnings.filterwarnings("ignore")
@@ -154,7 +154,7 @@ def _scenarios_block(df: pd.DataFrame) -> None:
     st.subheader("🔮 Scénarios prospectifs")
     st.caption("Scénarios basés sur des rythmes observés (fenêtres 7/14/30j), à interpréter comme guidance et non certitude.")
 
-    target_weight = float(get_target_weights()[-1])
+    target_weight = float(get_target_weights(st.session_state)[-1])
     scenarios = prospective_scenarios(df, target_weight)
 
     if not scenarios:
@@ -235,7 +235,7 @@ def main() -> None:
 
     # ── ETA objectif amélioré (existant + enrichi) ──────────────────────
     st.markdown("---")
-    target_weight = float(get_target_weights()[-1])
+    target_weight = float(get_target_weights(st.session_state)[-1])
 
     # QW3: Utiliser la période d'effort pour l'ETA
     from app.core.analytics import detect_current_effort

--- a/app/pages/Settings.py
+++ b/app/pages/Settings.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import streamlit as st
 
-from app.config import AppDefaults, DUPLICATE_STRATEGIES, get_target_weights, normalise_target_weights
+from app.config import AppDefaults, DUPLICATE_STRATEGIES
+from app.core.targets import get_target_weights, normalise_target_weights
 
 
 def main() -> None:

--- a/app/pages/Settings.py
+++ b/app/pages/Settings.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import streamlit as st
 
-from app.config import AppDefaults, DUPLICATE_STRATEGIES
-from app.core.targets import get_target_weights, normalise_target_weights
+from app.config import AppDefaults, DUPLICATE_STRATEGIES, get_target_weights, normalise_target_weights
 
 
 def main() -> None:
@@ -11,7 +10,7 @@ def main() -> None:
     defaults = AppDefaults()
 
     with st.form("settings_form"):
-        padded_goals = get_target_weights()
+        padded_goals = get_target_weights(st.session_state)
         st.number_input(
             "Poids objectif final (kg)",
             value=float(padded_goals[-1]),

--- a/tests/test_streamlit_smoke.py
+++ b/tests/test_streamlit_smoke.py
@@ -80,7 +80,7 @@ def test_settings_exposes_five_goals():
     assert "Objectif 5 (kg)" in labels
 
 
-def test_dashboard_migrates_legacy_four_goals_to_requested_five_goals():
+def test_dashboard_migrates_legacy_four_goals_missing_80_to_requested_five_goals():
     at = AppTest.from_file("app/pages/Dashboard.py")
     _state(at)
     at.session_state["target_weights"] = (100.0, 95.0, 90.0, 85.0)
@@ -89,4 +89,18 @@ def test_dashboard_migrates_legacy_four_goals_to_requested_five_goals():
     assert not at.exception
     assert at.session_state["target_weights"] == (100.0, 95.0, 90.0, 85.0, 80.0)
     assert at.session_state["target_weight"] == 80.0
+    assert any("Objectif 1: 100.0 kg" in str(c.value) for c in at.caption)
+    assert any("Objectif 5: 80.0 kg" in str(c.value) for c in at.caption)
+
+
+def test_dashboard_migrates_deployed_legacy_four_goals_missing_100_to_requested_five_goals():
+    at = AppTest.from_file("app/pages/Dashboard.py")
+    _state(at)
+    at.session_state["target_weights"] = (95.0, 90.0, 85.0, 80.0)
+    at.session_state["target_weight"] = 80.0
+    at.run(timeout=10)
+    assert not at.exception
+    assert at.session_state["target_weights"] == (100.0, 95.0, 90.0, 85.0, 80.0)
+    assert at.session_state["target_weight"] == 80.0
+    assert any("Objectif 1: 100.0 kg" in str(c.value) for c in at.caption)
     assert any("Objectif 5: 80.0 kg" in str(c.value) for c in at.caption)


### PR DESCRIPTION
### Motivation
- Centralise the target-weight logic so Streamlit pages import a stable implementation and avoid page-level import errors during deploys.
- Migrate legacy sessions that stored only four goals (95/90/85/80) to the new five-goal format while preserving expected graph behaviour.
- Ensure session state always stores five finite numeric targets and keep the final target sync as `target_weight`.

### Description
- Move implementations into `app.config`: introduce `DEFAULT_TARGETS`, `LEGACY_FOUR_TARGETS`, `TARGET_COUNT`, `_as_finite_float`, `normalise_target_weights` and `get_target_weights(session_state)` which normalises, migrates and persists targets into the provided `session_state` mapping.
- Replace the previous `app.core.targets` implementation with a compatibility shim that re-exports `DEFAULT_TARGETS`, `TARGET_COUNT`, `get_target_weights` and `normalise_target_weights` from `app.config` to maintain imports by pages.
- Update call sites in `app/core/session_state.py`, `app/pages/Dashboard.py`, `app/pages/Predictions.py` and `app/pages/Settings.py` to use the new `get_target_weights(st.session_state)` API and to import helpers from `app.config` where appropriate.
- Improve dashboard rendering in `_add_target_lines` to accept optional `x_values` and draw dashed scatter lines plus annotations when an x-range is available so target lines produce legend entries and readable labels.

### Testing
- Updated smoke tests in `tests/test_streamlit_smoke.py` to assert five goal inputs render and to cover both legacy-four variants (missing final 80 and missing initial 100) migration paths, and the test suite was run and passed.
- Streamlit page smoke tests for `Settings`, `Dashboard` and `Predictions` rendering were executed and completed without exceptions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1979f8d9908329baa9e0b18d352d8e)