### PR TITLE
Fix target helper imports for Streamlit pages

### DIFF
--- a/app/core/session_state.py
+++ b/app/core/session_state.py
@@ -6,7 +6,7 @@ import pandas as pd
 import streamlit as st
 
 from app.config import ALL_COLUMNS
-from app.config import DEFAULT_TARGETS, get_target_weights, normalise_target_weights
+from app.core.targets import DEFAULT_TARGETS, get_target_weights
 
 DEFAULT_WEIGHT_COLUMNS = ["Date", "Poids (Kgs)"]
 

--- a/app/core/targets.py
+++ b/app/core/targets.py
@@ -2,22 +2,72 @@
 
 from __future__ import annotations
 
-from collections.abc import MutableMapping
-from typing import Any
+from collections.abc import Iterable, MutableMapping
+import math
+from typing import Any, Final
 
-from app.config import (
-    DEFAULT_TARGETS,
-    LEGACY_FOUR_TARGETS,
-    TARGET_COUNT,
-    get_target_weights as _get_target_weights,
-    normalise_target_weights,
-)
+from app import config as _config
+
+DEFAULT_TARGETS: Final[tuple[float, float, float, float, float]] = tuple(
+    float(value) for value in getattr(_config, "DEFAULT_TARGETS", (100.0, 95.0, 90.0, 85.0, 80.0))
+)  # type: ignore[assignment]
+LEGACY_FOUR_TARGETS: Final[tuple[float, float, float, float]] = tuple(
+    float(value) for value in getattr(_config, "LEGACY_FOUR_TARGETS", (95.0, 90.0, 85.0, 80.0))
+)  # type: ignore[assignment]
+TARGET_COUNT: Final[int] = len(DEFAULT_TARGETS)
+
+
+def _as_finite_float(value: Any, default: float) -> float:
+    """Coerce ``value`` to a finite float, falling back to ``default``."""
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return float(default)
+    if not math.isfinite(numeric):
+        return float(default)
+    return numeric
+
+
+def _target_values(target_weights: Any = None) -> list[Any]:
+    if target_weights is None or isinstance(target_weights, (str, bytes)):
+        return []
+    if isinstance(target_weights, Iterable):
+        return list(target_weights)
+    return [target_weights]
+
+
+def _is_legacy_four_target_list(values: list[Any]) -> bool:
+    """Detect only true four-value legacy payloads, not explicit five-goal forms."""
+    if len(values) != len(LEGACY_FOUR_TARGETS):
+        return False
+
+    rounded_values = tuple(round(_as_finite_float(value, math.nan), 3) for value in values)
+    missing_final = tuple(round(target, 3) for target in DEFAULT_TARGETS[:-1])
+    missing_initial = tuple(round(target, 3) for target in LEGACY_FOUR_TARGETS)
+    return rounded_values in (missing_final, missing_initial)
+
+
+def normalise_target_weights(target_weights: Any = None) -> tuple[float, float, float, float, float]:
+    """Return exactly five finite numeric targets, migrating only real 4-goal sessions."""
+    values = _target_values(target_weights)
+    if _is_legacy_four_target_list(values):
+        return DEFAULT_TARGETS
+
+    normalised = [
+        _as_finite_float(values[idx], default) if idx < len(values) else float(default)
+        for idx, default in enumerate(DEFAULT_TARGETS)
+    ]
+    return tuple(normalised)  # type: ignore[return-value]
 
 
 def get_target_weights(session_state: MutableMapping[str, Any] | None = None) -> tuple[float, float, float, float, float]:
-    """Read target weights using the legacy no-argument Streamlit API when needed."""
+    """Read, migrate and persist the five configured target weights."""
     if session_state is None:
         import streamlit as st
 
         session_state = st.session_state
-    return _get_target_weights(session_state)
+
+    targets = normalise_target_weights(session_state.get("target_weights"))
+    session_state["target_weights"] = targets
+    session_state["target_weight"] = float(targets[-1])
+    return targets

--- a/app/pages/Dashboard.py
+++ b/app/pages/Dashboard.py
@@ -24,7 +24,7 @@ from app.core.analytics import (
 from app.core.data import data_quality_report
 from app.core.insights import detect_plateau
 from app.core.session_state import get_filtered_or_working_data
-from app.config import get_target_weights, normalise_target_weights
+from app.core.targets import get_target_weights, normalise_target_weights
 from app.ui.components import alert_banner, confidence_badge, empty_state, help_box, kpi_card
 
 

--- a/app/pages/Predictions.py
+++ b/app/pages/Predictions.py
@@ -18,7 +18,7 @@ from app.core.features import build_features
 from app.core.forecasting import forecast_with_ml, forecast_with_sarimax
 from app.core.insights import estimate_target_eta
 from app.core.session_state import get_filtered_or_working_data
-from app.config import get_target_weights
+from app.core.targets import get_target_weights
 from app.ui.components import alert_banner, empty_state, kpi_card
 
 warnings.filterwarnings("ignore")

--- a/app/pages/Settings.py
+++ b/app/pages/Settings.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import streamlit as st
 
 from app.config import AppDefaults, DUPLICATE_STRATEGIES
-from app.config import get_target_weights, normalise_target_weights
+from app.core.targets import get_target_weights, normalise_target_weights
 
 
 def main() -> None:


### PR DESCRIPTION
### Motivation
- Corriger l’`ImportError` causé par des pages Streamlit important `get_target_weights`/`normalise_target_weights` depuis `app.config` au démarrage.
- Isoler la logique de compatibilité des objectifs dans un module dédié pour éviter les dépendances d’import circulaires ou les erreurs d’importation à l’exécution.

### Description
- Ajouté/porté la logique de normalisation et migration des objectifs dans `app.core.targets` avec valeurs de repli lisibles depuis `app.config` si présent et fonctions `get_target_weights` et `normalise_target_weights` autonomes.
- Mis à jour les imports dans `app/pages/Settings.py`, `app/pages/Dashboard.py`, `app/pages/Predictions.py` et `app/core/session_state.py` pour utiliser `app.core.targets` au lieu de `app.config`.
- `ensure_session_defaults` continue d’initialiser `target_weights` mais appelle désormais `get_target_weights` depuis `app.core.targets` pour persister la forme normalisée.
- Conservé les valeurs par défaut et les règles de migration (4->5 objectifs) dans le nouveau module pour compatibilité ascendante et sécurité à l’import.

### Testing
- Exécution de `python -m compileall app` a réussi sans erreur de compilation. 
- Smoke assertions exécutées via un petit script vérifiant `normalise_target_weights` et `get_target_weights` ont réussi (`target helper smoke ok`).
- `pytest` sur `tests/test_core_v2.py` et `tests/test_streamlit_smoke.py` n’a pas pu être lancé en local à cause d’un `ModuleNotFoundError: No module named 'numpy'` dans l’environnement.
- `python -m pip install -r requirements.txt` a échoué en local à cause d’un accès au dépôt/p roxy retournant `403 Forbidden` pour `matplotlib==3.8.4`, bloquant l’installation complète des dépendances de test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a198a48e4548329b4d36551ae141fa1)