### PR TITLE
Fix trajectoire cible : calcul métier et intégration dashboard

### DIFF
--- a/app/core/target_trajectory.py
+++ b/app/core/target_trajectory.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pandas as pd
+
+
+DEFAULT_TARGET_TRAJECTORY_START_DATE = pd.Timestamp("2026-06-01")
+DEFAULT_WEEKLY_LOSS_TARGET = 2.0
+DEFAULT_FINAL_TARGET_WEIGHT = 80.0
+
+DATE_COL = "Date"
+WEIGHT_COL = "Poids (Kgs)"
+
+
+@dataclass(frozen=True)
+class TargetTrajectoryConfig:
+    """Business parameters for the main target trajectory."""
+
+    start_date: pd.Timestamp = DEFAULT_TARGET_TRAJECTORY_START_DATE
+    weekly_loss_target: float = DEFAULT_WEEKLY_LOSS_TARGET
+    final_target_weight: float = DEFAULT_FINAL_TARGET_WEIGHT
+
+    @classmethod
+    def from_values(
+        cls,
+        start_date: Any = DEFAULT_TARGET_TRAJECTORY_START_DATE,
+        weekly_loss_target: float = DEFAULT_WEEKLY_LOSS_TARGET,
+        final_target_weight: float = DEFAULT_FINAL_TARGET_WEIGHT,
+    ) -> "TargetTrajectoryConfig":
+        return cls(
+            start_date=pd.Timestamp(start_date).normalize(),
+            weekly_loss_target=float(weekly_loss_target),
+            final_target_weight=float(final_target_weight),
+        )
+
+
+def _prepare_weight_data(df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty or DATE_COL not in df.columns or WEIGHT_COL not in df.columns:
+        return pd.DataFrame(columns=[DATE_COL, WEIGHT_COL])
+
+    data = df[[DATE_COL, WEIGHT_COL]].copy()
+    data[DATE_COL] = pd.to_datetime(data[DATE_COL], errors="coerce").dt.normalize()
+    data[WEIGHT_COL] = pd.to_numeric(data[WEIGHT_COL], errors="coerce")
+    return data.dropna(subset=[DATE_COL, WEIGHT_COL]).sort_values(DATE_COL).reset_index(drop=True)
+
+
+def nearest_start_measurement(df: pd.DataFrame, start_date: pd.Timestamp) -> pd.Series | None:
+    """Return the real measured weight closest to the fixed trajectory start date."""
+    data = _prepare_weight_data(df)
+    if data.empty:
+        return None
+
+    normalized_start = pd.Timestamp(start_date).normalize()
+    distances = (data[DATE_COL] - normalized_start).abs()
+    return data.loc[distances.idxmin()]
+
+
+def build_target_trajectory(
+    df: pd.DataFrame,
+    config: TargetTrajectoryConfig | None = None,
+) -> dict[str, Any]:
+    """Build a capped target trajectory from a fixed date to the final target.
+
+    The curve starts at ``config.start_date`` using the closest real measured
+    weight to that date, descends at ``weekly_loss_target`` kg/week, and stops
+    exactly when ``final_target_weight`` is reached. It never goes below the
+    final target and never extends past it.
+    """
+    config = config or TargetTrajectoryConfig()
+    if config.weekly_loss_target <= 0:
+        return {"available": False, "message": "Le rythme cible doit être positif."}
+
+    measurement = nearest_start_measurement(df, config.start_date)
+    if measurement is None:
+        return {"available": False, "message": "Aucune mesure disponible pour ancrer la trajectoire cible."}
+
+    start_date = pd.Timestamp(config.start_date).normalize()
+    start_weight = float(measurement[WEIGHT_COL])
+    final_target = float(config.final_target_weight)
+    weekly_loss = float(config.weekly_loss_target)
+    daily_loss = weekly_loss / 7.0
+
+    if start_weight <= final_target:
+        dates = pd.DatetimeIndex([start_date])
+        values = [final_target]
+        target_days = 0.0
+        eta_date = start_date
+    else:
+        target_days = (start_weight - final_target) / daily_loss
+        full_days = int(target_days)
+        dates = pd.date_range(start_date, periods=full_days + 1, freq="D")
+        values = [max(start_weight - daily_loss * day, final_target) for day in range(full_days + 1)]
+
+        eta_date = start_date + pd.Timedelta(days=target_days)
+        if target_days > full_days:
+            dates = dates.append(pd.DatetimeIndex([eta_date]))
+            values.append(final_target)
+        else:
+            values[-1] = final_target
+
+    trajectory = pd.DataFrame({DATE_COL: dates, "Poids cible (kg)": values})
+    return {
+        "available": True,
+        "config": config,
+        "trajectory": trajectory,
+        "start_date": start_date,
+        "start_weight": start_weight,
+        "start_measurement_date": pd.Timestamp(measurement[DATE_COL]),
+        "weekly_loss_target": weekly_loss,
+        "final_target_weight": final_target,
+        "target_days": float(target_days),
+        "eta_date": eta_date,
+    }
+
+
+def target_weight_on_date(start_weight: float, date: pd.Timestamp, config: TargetTrajectoryConfig) -> float:
+    """Return the scheduled target weight for a date, capped at final target."""
+    elapsed_days = max((pd.Timestamp(date).normalize() - config.start_date).days, 0)
+    scheduled = float(start_weight) - (elapsed_days / 7.0 * config.weekly_loss_target)
+    return max(scheduled, config.final_target_weight)
+
+
+def compare_to_target_trajectory(
+    df: pd.DataFrame,
+    config: TargetTrajectoryConfig | None = None,
+) -> dict[str, Any]:
+    """Compare the latest measured weight with the corrected target trajectory."""
+    config = config or TargetTrajectoryConfig()
+    trajectory = build_target_trajectory(df, config)
+    if not trajectory.get("available"):
+        return trajectory
+
+    data = _prepare_weight_data(df)
+    if data.empty:
+        return {"available": False, "message": "Aucune mesure disponible."}
+
+    latest = data.iloc[-1]
+    current_date = pd.Timestamp(latest[DATE_COL])
+    current_weight = float(latest[WEIGHT_COL])
+    scheduled_weight = target_weight_on_date(float(trajectory["start_weight"]), current_date, config)
+    gap_kg = current_weight - scheduled_weight
+
+    start_weight = float(trajectory["start_weight"])
+    final_target = float(config.final_target_weight)
+    total_to_lose = max(start_weight - final_target, 0.0)
+    progress_pct = 100.0 if total_to_lose == 0 else (start_weight - current_weight) / total_to_lose * 100
+    progress_pct = max(0.0, min(100.0, progress_pct))
+
+    days_delta = gap_kg / (config.weekly_loss_target / 7.0) if config.weekly_loss_target > 0 else None
+    if gap_kg > 0.1:
+        status = "retard"
+    elif gap_kg < -0.1:
+        status = "avance"
+    else:
+        status = "aligné"
+
+    return {
+        **trajectory,
+        "current_date": current_date,
+        "current_weight": current_weight,
+        "scheduled_weight": scheduled_weight,
+        "gap_kg": gap_kg,
+        "days_delta": days_delta,
+        "status": status,
+        "progress_pct": progress_pct,
+    }

--- a/app/pages/Dashboard.py
+++ b/app/pages/Dashboard.py
@@ -24,6 +24,14 @@ from app.core.analytics import (
 from app.core.data import data_quality_report
 from app.core.insights import detect_plateau
 from app.core.session_state import get_filtered_or_working_data
+from app.core.target_trajectory import (
+    DEFAULT_FINAL_TARGET_WEIGHT,
+    DEFAULT_TARGET_TRAJECTORY_START_DATE,
+    DEFAULT_WEEKLY_LOSS_TARGET,
+    TargetTrajectoryConfig,
+    build_target_trajectory,
+    compare_to_target_trajectory,
+)
 from app.core.weight_summary import moving_average_by_days, summarize_weight_journey
 from app.core.targets import get_target_weights
 from app.ui.components import (
@@ -39,9 +47,6 @@ from app.ui.components import (
 )
 
 
-TARGET_TRAJECTORY_KG_PER_WEEK = -2.0
-TARGET_TRAJECTORY_DAILY_RATE = TARGET_TRAJECTORY_KG_PER_WEEK / 7
-TARGET_TRAJECTORY_LABEL = f"Trajectoire cible ({TARGET_TRAJECTORY_KG_PER_WEEK:g} kg/semaine)"
 TARGET_TRAJECTORY_CHART_KEY = "dashboard-target-trajectory-2kg-week"
 
 
@@ -167,7 +172,7 @@ def _trend_sentence(summary: dict, target_weight: float) -> tuple[str, str]:
         trend_text += f" Vous êtes à {abs(gap):.1f} kg de l’objectif principal ({target_weight:.1f} kg)."
     return trend_text, tone
 
-def _render_daily_overview(summary: dict, target_weight: float) -> None:
+def _render_daily_overview(summary: dict, target_weight: float, trajectory_status: dict | None = None) -> None:
     section_header(
         "Vue rapide",
         "Les cinq informations clés pour comprendre la situation en quelques secondes.",
@@ -184,13 +189,40 @@ def _render_daily_overview(summary: dict, target_weight: float) -> None:
     with cols[2]:
         kpi_card("Variation 30 jours", _format_delta(delta_30.value), help_text=_metric_help_for_period(delta_30))
     with cols[3]:
-        kpi_card("Écart objectif", _format_delta(summary["target_gap"]), help_text=f"Écart entre le poids actuel et l’objectif principal ({target_weight:.1f} kg).")
+        if trajectory_status and trajectory_status.get("available"):
+            kpi_card(
+                "Écart trajectoire",
+                _format_delta(trajectory_status.get("gap_kg")),
+                help_text=(
+                    f"Écart entre le poids actuel et la trajectoire cible corrigée "
+                    f"({trajectory_status['scheduled_weight']:.1f} kg attendu au {trajectory_status['current_date'].strftime('%d/%m/%Y')})."
+                ),
+            )
+        else:
+            kpi_card("Écart objectif", _format_delta(summary["target_gap"]), help_text=f"Écart entre le poids actuel et l’objectif principal ({target_weight:.1f} kg).")
     with cols[4]:
         trend_icon = {"Baisse": "📉", "Hausse": "📈", "Stable": "➡️"}.get(summary["trend_label"], "🔎")
         kpi_card("Tendance actuelle", f"{trend_icon} {summary['trend_label']}", help_text=summary["trend_explanation"])
 
     sentence, tone = _trend_sentence(summary, target_weight)
     insight_card("Lecture rapide", sentence, tone=tone, icon="🔎")
+
+    if trajectory_status and trajectory_status.get("available"):
+        status_label = {"retard": "en retard", "avance": "en avance", "aligné": "aligné"}.get(
+            trajectory_status.get("status"), "à comparer"
+        )
+        insight_card(
+            "Trajectoire cible corrigée",
+            (
+                f"Départ fixé au {trajectory_status['start_date'].strftime('%d/%m/%Y')} "
+                f"depuis {trajectory_status['start_weight']:.1f} kg, objectif "
+                f"{trajectory_status['final_target_weight']:.1f} kg estimé le "
+                f"{trajectory_status['eta_date'].strftime('%d/%m/%Y')}. "
+                f"Aujourd’hui : {trajectory_status['gap_kg']:+.1f} kg vs trajectoire ({status_label})."
+            ),
+            tone="success" if trajectory_status.get("status") in {"avance", "aligné"} else "warning",
+            icon="🎯",
+        )
 
 
 def _render_advanced_kpis(
@@ -206,6 +238,7 @@ def _render_advanced_kpis(
     height_m: float,
     is_startup: bool,
     last_date: pd.Timestamp,
+    trajectory_status: dict | None = None,
 ) -> tuple[pd.DataFrame, dict, dict]:
     analysis_df = effort_df if has_effort_period else df
     quality = data_quality_report(analysis_df)
@@ -255,7 +288,20 @@ def _render_advanced_kpis(
         streak_txt = f"{streak_icon} {streaks['current_streak']} mesures en {streaks['current_type']}"
         kpi_card("Série en cours", streak_txt, help_text=f"Record perte : {streaks['longest_loss']} mesures · Record gain : {streaks['longest_gain']} mesures")
 
-    if has_effort_period:
+    if trajectory_status and trajectory_status.get("available"):
+        progress = float(trajectory_status["progress_pct"])
+        progress_label = f"Progression vers {trajectory_status['final_target_weight']:.1f} kg"
+        status_label = {"retard": "en retard", "avance": "en avance", "aligné": "aligné"}.get(
+            trajectory_status.get("status"), "à comparer"
+        )
+        st.caption(
+            f"🎯 Trajectoire cible : {trajectory_status['scheduled_weight']:.1f} kg attendus au "
+            f"{trajectory_status['current_date'].strftime('%d/%m/%Y')} — "
+            f"écart {trajectory_status['gap_kg']:+.1f} kg ({status_label}). "
+            f"Atteinte théorique de {trajectory_status['final_target_weight']:.1f} kg : "
+            f"{trajectory_status['eta_date'].strftime('%d/%m/%Y')}."
+        )
+    elif has_effort_period:
         effort_initial_weight = float(effort_df["Poids (Kgs)"].iloc[0])
         if effort_initial_weight > target_weight:
             total = effort_initial_weight - target_weight
@@ -265,10 +311,10 @@ def _render_advanced_kpis(
         progress_label = f"Progression effort actuel vers {target_weight:.1f} kg"
     else:
         initial = df["Poids (Kgs)"].iloc[0]
-        final_target = targets[-1]
+        final_target = target_weight
         total = initial - final_target
         progress = ((initial - current) / total * 100) if total > 0 else 0.0
-        progress_label = f"Progression vers l’objectif final ({targets[-1]:.1f} kg)"
+        progress_label = f"Progression vers l’objectif final ({target_weight:.1f} kg)"
 
     progress_panel(
         progress_label,
@@ -340,6 +386,7 @@ def _render_main_weight_chart(
     effort_start: pd.Timestamp,
     effort_days: int,
     has_effort_period: bool,
+    trajectory_config: TargetTrajectoryConfig,
 ) -> None:
     section_header(
         "Évolution du poids",
@@ -368,6 +415,10 @@ def _render_main_weight_chart(
         with c3:
             show_forecast = st.checkbox("Trajectoire cible", value=True)
             st.caption("Les objectifs et la trajectoire font partie de la lecture par défaut ; désactivez-les ici si besoin.")
+            st.caption(
+                f"Paramètres trajectoire : départ {trajectory_config.start_date.strftime('%d/%m/%Y')} · "
+                f"-{trajectory_config.weekly_loss_target:g} kg/sem · objectif {trajectory_config.final_target_weight:g} kg"
+            )
 
     df["MA_7J"] = moving_average_by_days(df, 7)
     df["MA_30J"] = moving_average_by_days(df, 30)
@@ -412,21 +463,22 @@ def _render_main_weight_chart(
             hovertemplate="%{x|%d/%m/%Y}<br>Tendance: %{y:.2f} kg<extra></extra>",
         )
 
-    can_draw_target_trajectory = effort_start is not None and len(effort_df) >= 2
-    if show_forecast and can_draw_target_trajectory:
-        effort_initial_w = float(effort_df["Poids (Kgs)"].iloc[0])
-        traj_dates = pd.date_range(effort_start, periods=min(180, max(effort_days * 3, 90)), freq="D")
-        traj_values = [max(effort_initial_w + TARGET_TRAJECTORY_DAILY_RATE * i, target_weight) for i in range(len(traj_dates))]
+    target_trajectory = build_target_trajectory(df, trajectory_config)
+    if show_forecast and target_trajectory.get("available"):
+        trajectory_df = target_trajectory["trajectory"]
+        label = f"Trajectoire cible (-{trajectory_config.weekly_loss_target:g} kg/semaine)"
         fig.add_scatter(
-            x=traj_dates,
-            y=traj_values,
+            x=trajectory_df["Date"],
+            y=trajectory_df["Poids cible (kg)"],
             mode="lines",
-            name=TARGET_TRAJECTORY_LABEL,
+            name=label,
             line=dict(color="rgba(20,184,166,0.78)", width=1.7, dash="dashdot"),
             hovertemplate=(
                 "Date: %{x|%d/%m/%Y}<br>"
                 "Poids cible: %{y:.1f} kg<br>"
-                f"Rythme: {TARGET_TRAJECTORY_KG_PER_WEEK:g} kg/semaine<extra></extra>"
+                f"Départ: {target_trajectory['start_weight']:.1f} kg "
+                f"({target_trajectory['start_measurement_date'].strftime('%d/%m/%Y')})<br>"
+                f"Objectif final: {trajectory_config.final_target_weight:g} kg<extra></extra>"
             ),
         )
 
@@ -435,6 +487,33 @@ def _render_main_weight_chart(
     st.plotly_chart(fig, use_container_width=True, key=TARGET_TRAJECTORY_CHART_KEY)
     st.caption("Vue par défaut : poids mesuré prioritaire, moyenne mobile discrète, objectifs et trajectoire cible visibles.")
 
+
+
+def _trajectory_config_controls() -> TargetTrajectoryConfig:
+    """Expose explicit business parameters with required defaults."""
+    with st.sidebar.expander("Trajectoire cible", expanded=False):
+        start_date = st.date_input(
+            "Date de départ de trajectoire",
+            value=DEFAULT_TARGET_TRAJECTORY_START_DATE.date(),
+            help="Par défaut : 01/06/2026. La courbe ne démarre pas avant cette date ni à aujourd’hui.",
+        )
+        weekly_loss_target = st.number_input(
+            "Rythme cible (kg/semaine)",
+            min_value=0.1,
+            max_value=10.0,
+            value=float(DEFAULT_WEEKLY_LOSS_TARGET),
+            step=0.1,
+            help="Saisir une valeur positive : 2 signifie une perte cible de 2 kg par semaine.",
+        )
+        final_target_weight = st.number_input(
+            "Objectif final (kg)",
+            min_value=30.0,
+            max_value=250.0,
+            value=float(DEFAULT_FINAL_TARGET_WEIGHT),
+            step=0.5,
+            help="Par défaut : 80 kg. La trajectoire s’arrête à cet objectif et ne descend pas en dessous.",
+        )
+    return TargetTrajectoryConfig.from_values(start_date, weekly_loss_target, final_target_weight)
 
 def main() -> None:
     df = _df()
@@ -457,7 +536,9 @@ def main() -> None:
 
     height_m = st.session_state.get("height_m", 1.82)
     targets = get_target_weights(st.session_state)
-    target_weight = float(targets[-1])
+    trajectory_config = _trajectory_config_controls()
+    target_weight = float(trajectory_config.final_target_weight)
+    trajectory_status = compare_to_target_trajectory(df, trajectory_config)
     daily_summary = summarize_weight_journey(df, target_weight)
     analysis_df = effort_df if has_effort_period else df
     prog = progression_score(analysis_df, target_weight)
@@ -470,7 +551,7 @@ def main() -> None:
     )
 
     if daily_summary.get("valid"):
-        _render_daily_overview(daily_summary, target_weight)
+        _render_daily_overview(daily_summary, target_weight, trajectory_status)
     else:
         st.warning(daily_summary.get("message", "Données insuffisantes pour calculer les indicateurs."))
 
@@ -485,7 +566,7 @@ def main() -> None:
             f"{delta_icon} **{delta_text} kg** ({effort_initial:.1f} → {current:.1f} kg)"
         )
 
-    _render_main_weight_chart(df, target_weight, targets, effort_df, effort_start, effort_days, has_effort_period)
+    _render_main_weight_chart(df, target_weight, targets, effort_df, effort_start, effort_days, has_effort_period, trajectory_config)
 
     tab_analysis, tab_forecast, tab_history, tab_settings = st.tabs(
         ["Analyse détaillée", "Prévisions", "Historique", "Paramètres / objectifs"]
@@ -519,6 +600,7 @@ def main() -> None:
                 height_m,
                 is_startup,
                 last_date,
+                trajectory_status,
             )
 
         with st.expander("💡 Insights détaillés", expanded=False):
@@ -543,6 +625,16 @@ def main() -> None:
 
     with tab_forecast:
         section_header("Prévisions", "Les projections restent prudentes et sont séparées de la lecture principale.", "🔮")
+        if trajectory_status.get("available"):
+            delay_days = trajectory_status.get("days_delta")
+            delay_text = ""
+            if delay_days is not None:
+                delay_text = f" · {abs(delay_days):.0f} jour(s) {'de retard' if delay_days > 0 else 'd’avance' if delay_days < 0 else 'd’écart'}"
+            st.info(
+                f"🎯 Trajectoire métier corrigée : objectif {trajectory_status['final_target_weight']:.1f} kg le "
+                f"**{trajectory_status['eta_date'].strftime('%d/%m/%Y')}**. "
+                f"Écart actuel : **{trajectory_status['gap_kg']:+.1f} kg**{delay_text}."
+            )
         projection = daily_summary.get("projection", {}) if daily_summary.get("valid") else {}
         if projection.get("available") and not projection.get("reached"):
             eta = projection["eta"].strftime("%d/%m/%Y")

--- a/tests/test_target_trajectory.py
+++ b/tests/test_target_trajectory.py
@@ -1,0 +1,81 @@
+import math
+
+import pandas as pd
+
+from app.core.target_trajectory import (
+    DEFAULT_FINAL_TARGET_WEIGHT,
+    DEFAULT_TARGET_TRAJECTORY_START_DATE,
+    DEFAULT_WEEKLY_LOSS_TARGET,
+    TargetTrajectoryConfig,
+    build_target_trajectory,
+    compare_to_target_trajectory,
+)
+
+
+def test_target_trajectory_starts_on_fixed_date_uses_exact_measurement_and_stops_at_80():
+    df = pd.DataFrame(
+        {
+            "Date": pd.to_datetime(["2025-01-01", "2026-06-01", "2026-06-10"]),
+            "Poids (Kgs)": [120.0, 105.0, 102.0],
+        }
+    )
+
+    result = build_target_trajectory(df)
+    trajectory = result["trajectory"]
+
+    assert result["available"] is True
+    assert result["start_date"] == DEFAULT_TARGET_TRAJECTORY_START_DATE
+    assert result["start_measurement_date"] == DEFAULT_TARGET_TRAJECTORY_START_DATE
+    assert result["start_weight"] == 105.0
+    assert trajectory["Date"].iloc[0] == DEFAULT_TARGET_TRAJECTORY_START_DATE
+    assert trajectory["Poids cible (kg)"].iloc[0] == 105.0
+    assert trajectory["Poids cible (kg)"].min() == DEFAULT_FINAL_TARGET_WEIGHT
+    assert trajectory["Poids cible (kg)"].iloc[-1] == DEFAULT_FINAL_TARGET_WEIGHT
+    assert math.isclose(result["target_days"], 87.5)
+    assert result["eta_date"] == DEFAULT_TARGET_TRAJECTORY_START_DATE + pd.Timedelta(days=87.5)
+    assert trajectory["Date"].iloc[-1] == result["eta_date"]
+
+
+def test_target_trajectory_uses_nearest_measurement_to_fixed_start_date():
+    df = pd.DataFrame(
+        {
+            "Date": pd.to_datetime(["2026-05-29", "2026-06-04"]),
+            "Poids (Kgs)": [106.0, 104.0],
+        }
+    )
+
+    result = build_target_trajectory(df)
+
+    assert result["start_date"] == DEFAULT_TARGET_TRAJECTORY_START_DATE
+    assert result["start_measurement_date"] == pd.Timestamp("2026-05-29")
+    assert result["start_weight"] == 106.0
+
+
+def test_compare_to_target_trajectory_reports_gap_status_and_progress():
+    df = pd.DataFrame(
+        {
+            "Date": pd.to_datetime(["2026-06-01", "2026-06-08"]),
+            "Poids (Kgs)": [105.0, 104.0],
+        }
+    )
+
+    result = compare_to_target_trajectory(df)
+
+    assert result["scheduled_weight"] == 103.0
+    assert result["gap_kg"] == 1.0
+    assert result["status"] == "retard"
+    assert result["progress_pct"] == 4.0
+
+
+def test_target_trajectory_supports_explicit_business_parameters():
+    df = pd.DataFrame({"Date": pd.to_datetime(["2026-07-01"]), "Poids (Kgs)": [90.0]})
+    config = TargetTrajectoryConfig.from_values("2026-07-01", weekly_loss_target=1.0, final_target_weight=85.0)
+
+    result = build_target_trajectory(df, config)
+
+    assert result["start_date"] == pd.Timestamp("2026-07-01")
+    assert result["weekly_loss_target"] == 1.0
+    assert result["final_target_weight"] == 85.0
+    assert math.isclose(result["target_days"], 35.0)
+    assert result["eta_date"] == pd.Timestamp("2026-08-05")
+    assert DEFAULT_WEEKLY_LOSS_TARGET == 2.0


### PR DESCRIPTION
### Motivation
- Corriger la logique de calcul de la « Trajectoire cible (-2 kg/semaine) » pour appliquer strictement la règle métier (départ fixe, rythme -2 kg/sem, arrêt à 80 kg et usage de la mesure réelle la plus proche de la date de départ).
- Éviter les démarrages incorrects (première date historique, aujourd’hui) et empêcher la prolongation ou le dépassement sous 80 kg.
- Exposer des paramètres métier clairs (date de départ, rythme hebdo, objectif final) tout en conservant les valeurs par défaut demandées.

### Description
- Ajout d’un nouveau module `app/core/target_trajectory.py` qui contient `TargetTrajectoryConfig` et fonctions principales : `nearest_start_measurement`, `build_target_trajectory`, `target_weight_on_date` et `compare_to_target_trajectory`, avec les valeurs par défaut `start_date = 2026-06-01`, `weekly_loss_target = 2.0` et `final_target_weight = 80.0`.
- Intégration dans `app/pages/Dashboard.py` pour : ajouter les contrôles sidebar (`_trajectory_config_controls`), calculer `trajectory_status = compare_to_target_trajectory(df, trajectory_config)`, transmettre la `trajectory_config` à la fonction de rendu du graphique et dessiner la courbe corrigée (ligne `dashdot`) issue de `build_target_trajectory` en partant de la mesure réelle la plus proche de 01/06/2026 et en s’arrêtant exactement à 80 kg.
- Ajout d’information et KPIs dans le dashboard : affichage de l’`Écart trajectoire`, carte d’insight « Trajectoire cible corrigée », texte résumé d’ETA, avance/retard (`days_delta`) et progression vers l’objectif final (utilisé pour les captions et le panneau de progression).
- Ajout de tests unitaires `tests/test_target_trajectory.py` couvrant le démarrage sur la date fixe avec mesure exacte, l’utilisation de la mesure la plus proche, l’arrêt plafonné à 80 kg, le calcul d’écart/statut et le support des paramètres explicites.

### Testing
- `python -m py_compile app/core/target_trajectory.py app/pages/Dashboard.py tests/test_target_trajectory.py` a été exécuté avec succès pour vérifier la syntaxe des fichiers modifiés.
- `git diff --check` / vérifications statiques ont été exécutées et ne rapportent d’erreurs de style bloquantes.
- `pytest -q tests/test_target_trajectory.py` n’a pas pu être exécuté dans l’environnement CI local car la dépendance native `numpy` est absente, empêchant l’exécution automatique des tests unitaires.
- Tentative d’installation des dépendances via `python -m pip install -r requirements.txt` a échoué par restrictions d’accès (erreur tunnel/403) dans l’environnement de build, empêchant l’exécution complète des suites de tests end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26b33feb8c8329b54341a09e1cf37e)