### PR TITLE
Clean up user-facing trajectory wording

### DIFF
--- a/app/core/analytics.py
+++ b/app/core/analytics.py
@@ -373,13 +373,13 @@ def _merge_consecutive_phases(phases: list[Phase]) -> list[Phase]:
 # ---------------------------------------------------------------------------
 
 def period_comparison(df: pd.DataFrame) -> dict[str, Any]:
-    """Compare semaine courante vs précédente, mois courant vs précédent."""
+    """Compare la semaine courante à la précédente, puis le mois courant au précédent."""
     if len(df) < 7:
         return {"week": None, "month": None}
     data = df.sort_values("Date")
     last_date = data["Date"].max()
 
-    # Semaine courante vs précédente
+    # Semaine courante par rapport à la précédente
     week_end = last_date
     week_start = week_end - pd.Timedelta(days=6)
     prev_week_end = week_start - pd.Timedelta(days=1)
@@ -398,7 +398,7 @@ def period_comparison(df: pd.DataFrame) -> dict[str, Any]:
             "previous_count": len(prev_week),
         }
 
-    # Mois courant vs précédent
+    # Mois courant par rapport au précédent
     month_start = last_date.replace(day=1)
     prev_month_end = month_start - pd.Timedelta(days=1)
     prev_month_start = prev_month_end.replace(day=1)
@@ -738,7 +738,7 @@ def compute_trend_ema(df: pd.DataFrame, span: int = 7) -> pd.DataFrame:
 
 
 # ---------------------------------------------------------------------------
-# 17. Comparaison rythme actuel vs rythme nécessaire
+# 17. Comparaison rythme actuel par rapport au rythme nécessaire
 # ---------------------------------------------------------------------------
 
 def pace_comparison(df: pd.DataFrame, target_weight: float, target_date: pd.Timestamp | None = None) -> dict[str, Any]:
@@ -787,9 +787,9 @@ def pace_comparison(df: pd.DataFrame, target_weight: float, target_date: pd.Time
         elif ratio >= 1.0:
             interp = f"Bon rythme ! Vous perdez **{abs(current_pace):.2f} kg/sem**, aligné avec le rythme nécessaire ({abs(required_pace):.2f} kg/sem)."
         elif ratio >= 0.5:
-            interp = f"Rythme un peu lent : **{abs(current_pace):.2f} kg/sem** vs {abs(required_pace):.2f} kg/sem nécessaire."
+            interp = f"Rythme un peu lent : **{abs(current_pace):.2f} kg/sem** par rapport à {abs(required_pace):.2f} kg/sem nécessaire."
         else:
-            interp = f"Rythme insuffisant : **{abs(current_pace):.2f} kg/sem** vs {abs(required_pace):.2f} kg/sem nécessaire."
+            interp = f"Rythme insuffisant : **{abs(current_pace):.2f} kg/sem** par rapport à {abs(required_pace):.2f} kg/sem nécessaire."
 
     return {
         "current_pace": current_pace,

--- a/app/pages/Dashboard.py
+++ b/app/pages/Dashboard.py
@@ -115,6 +115,36 @@ def _format_value(value: float | None, suffix: str = " kg") -> str:
     return f"{value:.2f}{suffix}"
 
 
+def _format_fr_number(value: float, decimals: int = 1, *, trim_zeros: bool = True) -> str:
+    formatted = f"{float(value):.{decimals}f}"
+    if trim_zeros:
+        formatted = formatted.rstrip("0").rstrip(".")
+    return formatted.replace(".", ",")
+
+
+def _format_fr_kg(value: float, decimals: int = 1, *, trim_zeros: bool = True) -> str:
+    return f"{_format_fr_number(value, decimals=decimals, trim_zeros=trim_zeros)} kg"
+
+
+def _trajectory_gap_label(trajectory_status: dict) -> str:
+    gap = float(trajectory_status.get("gap_kg", 0.0))
+    status = trajectory_status.get("status")
+    gap_text = _format_fr_kg(abs(gap), decimals=1)
+
+    if status == "avance":
+        return f"{gap_text} en dessous"
+    if status == "aligné":
+        return "Aligné"
+    return f"{gap_text} au-dessus"
+
+
+def _trajectory_position_sentence(trajectory_status: dict) -> str:
+    status = trajectory_status.get("status")
+    if status == "aligné":
+        return "Vous êtes actuellement aligné avec la trajectoire cible."
+    return f"Vous êtes actuellement à {_trajectory_gap_label(trajectory_status)} de la trajectoire cible."
+
+
 def _metric_help_for_period(period) -> str:
     if period.value is None:
         return period.reason or "Données insuffisantes pour cette période."
@@ -183,7 +213,7 @@ def _render_daily_overview(summary: dict, target_weight: float, trajectory_statu
     delta_30 = summary["delta_30"]
     cols = st.columns(5)
     with cols[0]:
-        kpi_card("Poids actuel", _format_value(summary["current"]), _format_delta(summary["previous_delta"]), "Dernière mesure vs mesure précédente.")
+        kpi_card("Poids actuel", _format_value(summary["current"]), _format_delta(summary["previous_delta"]), "Dernière mesure par rapport à la mesure précédente.")
     with cols[1]:
         kpi_card("Variation 7 jours", _format_delta(delta_7.value), help_text=_metric_help_for_period(delta_7))
     with cols[2]:
@@ -192,10 +222,10 @@ def _render_daily_overview(summary: dict, target_weight: float, trajectory_statu
         if trajectory_status and trajectory_status.get("available"):
             kpi_card(
                 "Écart trajectoire",
-                _format_delta(trajectory_status.get("gap_kg")),
+                _trajectory_gap_label(trajectory_status),
                 help_text=(
-                    f"Écart entre le poids actuel et la trajectoire cible corrigée "
-                    f"({trajectory_status['scheduled_weight']:.1f} kg attendu au {trajectory_status['current_date'].strftime('%d/%m/%Y')})."
+                    f"Poids attendu au {trajectory_status['current_date'].strftime('%d/%m/%Y')} "
+                    f"dans la trajectoire cible : {_format_fr_kg(trajectory_status['scheduled_weight'])}."
                 ),
             )
         else:
@@ -208,17 +238,14 @@ def _render_daily_overview(summary: dict, target_weight: float, trajectory_statu
     insight_card("Lecture rapide", sentence, tone=tone, icon="🔎")
 
     if trajectory_status and trajectory_status.get("available"):
-        status_label = {"retard": "en retard", "avance": "en avance", "aligné": "aligné"}.get(
-            trajectory_status.get("status"), "à comparer"
-        )
         insight_card(
-            "Trajectoire cible corrigée",
+            "Trajectoire cible",
             (
-                f"Départ fixé au {trajectory_status['start_date'].strftime('%d/%m/%Y')} "
-                f"depuis {trajectory_status['start_weight']:.1f} kg, objectif "
-                f"{trajectory_status['final_target_weight']:.1f} kg estimé le "
-                f"{trajectory_status['eta_date'].strftime('%d/%m/%Y')}. "
-                f"Aujourd’hui : {trajectory_status['gap_kg']:+.1f} kg vs trajectoire ({status_label})."
+                f"Objectif {_format_fr_kg(trajectory_status['final_target_weight'])} estimé autour du "
+                f"{trajectory_status['eta_date'].strftime('%d/%m/%Y')}, avec une trajectoire de "
+                f"-{_format_fr_kg(trajectory_status['weekly_loss_target'])}/semaine depuis le "
+                f"{trajectory_status['start_date'].strftime('%d/%m/%Y')}. "
+                f"{_trajectory_position_sentence(trajectory_status)}"
             ),
             tone="success" if trajectory_status.get("status") in {"avance", "aligné"} else "warning",
             icon="🎯",
@@ -290,15 +317,12 @@ def _render_advanced_kpis(
 
     if trajectory_status and trajectory_status.get("available"):
         progress = float(trajectory_status["progress_pct"])
-        progress_label = f"Progression vers {trajectory_status['final_target_weight']:.1f} kg"
-        status_label = {"retard": "en retard", "avance": "en avance", "aligné": "aligné"}.get(
-            trajectory_status.get("status"), "à comparer"
-        )
+        progress_label = f"Progression vers {_format_fr_kg(trajectory_status['final_target_weight'])}"
         st.caption(
-            f"🎯 Trajectoire cible : {trajectory_status['scheduled_weight']:.1f} kg attendus au "
-            f"{trajectory_status['current_date'].strftime('%d/%m/%Y')} — "
-            f"écart {trajectory_status['gap_kg']:+.1f} kg ({status_label}). "
-            f"Atteinte théorique de {trajectory_status['final_target_weight']:.1f} kg : "
+            f"🎯 Trajectoire cible : {_format_fr_kg(trajectory_status['scheduled_weight'])} attendus au "
+            f"{trajectory_status['current_date'].strftime('%d/%m/%Y')}. "
+            f"{_trajectory_position_sentence(trajectory_status)} "
+            f"Objectif {_format_fr_kg(trajectory_status['final_target_weight'])} estimé autour du "
             f"{trajectory_status['eta_date'].strftime('%d/%m/%Y')}."
         )
     elif has_effort_period:
@@ -308,13 +332,13 @@ def _render_advanced_kpis(
             progress = ((effort_initial_weight - current) / total * 100) if total > 0 else 0.0
         else:
             progress = 100.0
-        progress_label = f"Progression effort actuel vers {target_weight:.1f} kg"
+        progress_label = f"Progression effort actuel vers {_format_fr_kg(target_weight)}"
     else:
         initial = df["Poids (Kgs)"].iloc[0]
         final_target = target_weight
         total = initial - final_target
         progress = ((initial - current) / total * 100) if total > 0 else 0.0
-        progress_label = f"Progression vers l’objectif final ({target_weight:.1f} kg)"
+        progress_label = f"Progression vers l’objectif final ({_format_fr_kg(target_weight)})"
 
     progress_panel(
         progress_label,
@@ -329,9 +353,9 @@ def _render_advanced_kpis(
     if milestone.get("eta_days") is not None:
         conf = milestone.get("eta_confidence", "")
         conf_note = f" (confiance: {conf})" if conf else ""
-        ms_text += f" — ETA: **~{milestone['eta_days']} jours**{conf_note}"
+        ms_text += f" — Date estimée : **~{milestone['eta_days']} jours**{conf_note}"
     elif milestone.get("eta_confidence") == "fragile":
-        ms_text += " — ETA: disponible après 7+ mesures"
+        ms_text += " — Date estimée disponible après 7+ mesures"
     st.caption(ms_text)
 
     plateau = detect_plateau(analysis_df, window=14)
@@ -626,14 +650,10 @@ def main() -> None:
     with tab_forecast:
         section_header("Prévisions", "Les projections restent prudentes et sont séparées de la lecture principale.", "🔮")
         if trajectory_status.get("available"):
-            delay_days = trajectory_status.get("days_delta")
-            delay_text = ""
-            if delay_days is not None:
-                delay_text = f" · {abs(delay_days):.0f} jour(s) {'de retard' if delay_days > 0 else 'd’avance' if delay_days < 0 else 'd’écart'}"
             st.info(
-                f"🎯 Trajectoire métier corrigée : objectif {trajectory_status['final_target_weight']:.1f} kg le "
+                f"🎯 Plan d’atteinte de l’objectif : {_format_fr_kg(trajectory_status['final_target_weight'])} autour du "
                 f"**{trajectory_status['eta_date'].strftime('%d/%m/%Y')}**. "
-                f"Écart actuel : **{trajectory_status['gap_kg']:+.1f} kg**{delay_text}."
+                f"{_trajectory_position_sentence(trajectory_status)}"
             )
         projection = daily_summary.get("projection", {}) if daily_summary.get("valid") else {}
         if projection.get("available") and not projection.get("reached"):

--- a/app/pages/Insights.py
+++ b/app/pages/Insights.py
@@ -222,24 +222,24 @@ def main() -> None:
     period = period_comparison(analysis_df)
     cmp_cols = st.columns(2)
     with cmp_cols[0]:
-        st.markdown("**Semaine courante vs précédente**")
+        st.markdown("**Semaine courante par rapport à la précédente**")
         if period["week"]:
             w = period["week"]
             delta = w["delta"]
             icon = "📉" if delta < -0.1 else "📈" if delta > 0.1 else "➡️"
             st.metric("Delta hebdo", f"{icon} {delta:+.2f} kg",
-                      f"{w['current_mean']:.1f} vs {w['previous_mean']:.1f} kg")
+                      f"{w['current_mean']:.1f} par rapport à {w['previous_mean']:.1f} kg")
         else:
             st.info("Données insuffisantes")
         st.caption("Base de calcul: moyennes hebdomadaires calendaires.")
     with cmp_cols[1]:
-        st.markdown("**Mois courant vs précédent**")
+        st.markdown("**Mois courant par rapport au précédent**")
         if period["month"]:
             m = period["month"]
             delta = m["delta"]
             icon = "📉" if delta < -0.1 else "📈" if delta > 0.1 else "➡️"
             st.metric("Delta mensuel", f"{icon} {delta:+.2f} kg",
-                      f"{m['current_mean']:.1f} vs {m['previous_mean']:.1f} kg")
+                      f"{m['current_mean']:.1f} par rapport à {m['previous_mean']:.1f} kg")
         else:
             st.info("Données insuffisantes")
         st.caption("Base de calcul: moyennes mensuelles calendaires.")

--- a/app/pages/Journal.py
+++ b/app/pages/Journal.py
@@ -28,7 +28,7 @@ def main() -> None:
     page_hero(
         "Données",
         "Journal",
-        "Ajoutez, corrigez et exportez vos mesures tout en conservant les colonnes personnalisées de votre CSV.",
+        "Ajoutez, modifiez et exportez vos mesures tout en conservant les colonnes personnalisées de votre CSV.",
         meta=f"{len(df)} ligne(s) en session" if not df.empty else "Aucune mesure en session",
     )
     if df.empty:

--- a/app/pages/Predictions.py
+++ b/app/pages/Predictions.py
@@ -29,7 +29,7 @@ def _df() -> pd.DataFrame:
 
 
 def _model_comparison(df: pd.DataFrame) -> None:
-    st.subheader("Comparaison Régression Linéaire vs Random Forest")
+    st.subheader("Comparaison Régression Linéaire et Random Forest")
     if len(df) < 10:
         st.warning("Données insuffisantes pour comparer les modèles.")
         return


### PR DESCRIPTION
### Motivation

- Improve the dashboard UX by removing internal/developer terms such as “corrigé”, “vs” and raw calculation phrasing from user-facing text.
- Present target trajectory information in a clear, non-technical French phrasing with proper rounding and unit formatting.
- Keep the existing calculation logic unchanged and only modify the visible wording so users see a professional, stable message.

### Description

- Added French-friendly formatting helpers `_format_fr_number` and `_format_fr_kg` and new helpers `_trajectory_gap_label` and `_trajectory_position_sentence` in `app/pages/Dashboard.py` to produce rounded, locale-style kg values and human-readable position sentences.
- Replaced the dashboard trajectory card title and copy with a neutral, user-friendly version (`"Trajectoire cible"`) that states the objective, estimated ETA, weekly trajectory and the user’s position (au-dessus / en dessous / aligné). 
- Updated KPI/help text and forecast panel phrasing in `app/pages/Dashboard.py` to remove any mention of corrections or internal status, and adjusted related UI copy in `app/pages/Insights.py`, `app/pages/Journal.py`, `app/pages/Predictions.py` and `app/core/analytics.py` to replace `vs` and developer-style wording with natural French (`par rapport à`, etc.).
- Small copy refinements for consistency (progress labels, milestone ETA phrasing, and comparison captions) to match the dashboard style.

### Testing

- Ran `python -m py_compile app/pages/Dashboard.py app/pages/Insights.py app/pages/Journal.py app/pages/Predictions.py app/core/analytics.py`, which succeeded.
- Searched the codebase for banned/internal terms with `rg` and confirmed no remaining visible occurrences under `app/`.
- Attempted `pytest -q` but tests could not run in this environment due to a missing dependency (`ModuleNotFoundError: No module named 'numpy'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26ba43bdac8329be14ad964321d82a)