### PR TITLE
Fix target trajectory reference point

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Application Streamlit de suivi de poids avec analyses comportementales avancées
 | **Tendance EMA** | Poids lissé comme KPI principal (filtre les fluctuations quotidiennes) |
 | **Détection yo-yo** | Analyse factuelle des rebonds après chaque pause de suivi |
 | **Détection d'effort** | Identification automatique de la période d'effort actuelle (gap > 21j = nouveau départ) |
-| **Trajectoire cible** | Corridor ±1 kg autour d'une pente cible de -2 kg/semaine |
+| **Trajectoire cible** | Courbe cible fixe de 106,2 kg le 26/05/2026 vers 80 kg à -2 kg/semaine, arrêtée à l’objectif |
 | **Phase de démarrage** | Les 7 premiers jours = "données fragiles", pas d'extrapolation |
 | **Milestone intelligent** | Prochain palier avec ETA réaliste (gardes-fous physiologiques) |
 | **Vue hebdomadaire** | Bar chart consolidé avec coloration baisse/hausse |

--- a/app/core/target_trajectory.py
+++ b/app/core/target_trajectory.py
@@ -6,7 +6,8 @@ from typing import Any
 import pandas as pd
 
 
-DEFAULT_TARGET_TRAJECTORY_START_DATE = pd.Timestamp("2026-06-01")
+DEFAULT_TARGET_TRAJECTORY_START_DATE = pd.Timestamp("2026-05-26")
+DEFAULT_TARGET_TRAJECTORY_START_WEIGHT = 106.2
 DEFAULT_WEEKLY_LOSS_TARGET = 2.0
 DEFAULT_FINAL_TARGET_WEIGHT = 80.0
 
@@ -19,6 +20,7 @@ class TargetTrajectoryConfig:
     """Business parameters for the main target trajectory."""
 
     start_date: pd.Timestamp = DEFAULT_TARGET_TRAJECTORY_START_DATE
+    start_weight: float = DEFAULT_TARGET_TRAJECTORY_START_WEIGHT
     weekly_loss_target: float = DEFAULT_WEEKLY_LOSS_TARGET
     final_target_weight: float = DEFAULT_FINAL_TARGET_WEIGHT
 
@@ -28,9 +30,12 @@ class TargetTrajectoryConfig:
         start_date: Any = DEFAULT_TARGET_TRAJECTORY_START_DATE,
         weekly_loss_target: float = DEFAULT_WEEKLY_LOSS_TARGET,
         final_target_weight: float = DEFAULT_FINAL_TARGET_WEIGHT,
+        *,
+        start_weight: float = DEFAULT_TARGET_TRAJECTORY_START_WEIGHT,
     ) -> "TargetTrajectoryConfig":
         return cls(
             start_date=pd.Timestamp(start_date).normalize(),
+            start_weight=float(start_weight),
             weekly_loss_target=float(weekly_loss_target),
             final_target_weight=float(final_target_weight),
         )
@@ -46,15 +51,13 @@ def _prepare_weight_data(df: pd.DataFrame) -> pd.DataFrame:
     return data.dropna(subset=[DATE_COL, WEIGHT_COL]).sort_values(DATE_COL).reset_index(drop=True)
 
 
-def nearest_start_measurement(df: pd.DataFrame, start_date: pd.Timestamp) -> pd.Series | None:
-    """Return the real measured weight closest to the fixed trajectory start date."""
-    data = _prepare_weight_data(df)
-    if data.empty:
-        return None
+def fixed_start_measurement(_df: pd.DataFrame, config: TargetTrajectoryConfig) -> pd.Series:
+    """Return the explicit reference point used to anchor the trajectory.
 
-    normalized_start = pd.Timestamp(start_date).normalize()
-    distances = (data[DATE_COL] - normalized_start).abs()
-    return data.loc[distances.idxmin()]
+    The business rule intentionally does not infer this point from the data set:
+    it must always be 26/05/2026 at 106.2 kg by default.
+    """
+    return pd.Series({DATE_COL: config.start_date, WEIGHT_COL: config.start_weight})
 
 
 def build_target_trajectory(
@@ -63,21 +66,20 @@ def build_target_trajectory(
 ) -> dict[str, Any]:
     """Build a capped target trajectory from a fixed date to the final target.
 
-    The curve starts at ``config.start_date`` using the closest real measured
-    weight to that date, descends at ``weekly_loss_target`` kg/week, and stops
-    exactly when ``final_target_weight`` is reached. It never goes below the
-    final target and never extends past it.
+    The curve starts at the explicit business reference point in ``config``
+    (26/05/2026 at 106.2 kg by default), descends at
+    ``weekly_loss_target`` kg/week, and stops exactly when
+    ``final_target_weight`` is reached. It never goes below the final target
+    and never extends past it.
     """
     config = config or TargetTrajectoryConfig()
     if config.weekly_loss_target <= 0:
         return {"available": False, "message": "Le rythme cible doit être positif."}
 
-    measurement = nearest_start_measurement(df, config.start_date)
-    if measurement is None:
-        return {"available": False, "message": "Aucune mesure disponible pour ancrer la trajectoire cible."}
+    measurement = fixed_start_measurement(df, config)
 
     start_date = pd.Timestamp(config.start_date).normalize()
-    start_weight = float(measurement[WEIGHT_COL])
+    start_weight = float(config.start_weight)
     final_target = float(config.final_target_weight)
     weekly_loss = float(config.weekly_loss_target)
     daily_loss = weekly_loss / 7.0
@@ -117,7 +119,8 @@ def build_target_trajectory(
 
 def target_weight_on_date(start_weight: float, date: pd.Timestamp, config: TargetTrajectoryConfig) -> float:
     """Return the scheduled target weight for a date, capped at final target."""
-    elapsed_days = max((pd.Timestamp(date).normalize() - config.start_date).days, 0)
+    start_date = pd.Timestamp(config.start_date).normalize()
+    elapsed_days = max((pd.Timestamp(date).normalize() - start_date).days, 0)
     scheduled = float(start_weight) - (elapsed_days / 7.0 * config.weekly_loss_target)
     return max(scheduled, config.final_target_weight)
 

--- a/app/pages/Dashboard.py
+++ b/app/pages/Dashboard.py
@@ -27,6 +27,7 @@ from app.core.session_state import get_filtered_or_working_data
 from app.core.target_trajectory import (
     DEFAULT_FINAL_TARGET_WEIGHT,
     DEFAULT_TARGET_TRAJECTORY_START_DATE,
+    DEFAULT_TARGET_TRAJECTORY_START_WEIGHT,
     DEFAULT_WEEKLY_LOSS_TARGET,
     TargetTrajectoryConfig,
     build_target_trajectory,
@@ -71,7 +72,7 @@ def _add_target_lines(
     x_range = [x_values.min(), x_values.max()]
     for idx, target in enumerate(target_values, start=1):
         color = colors[(idx - 1) % len(colors)]
-        label = f"{label_prefix} {idx}: {float(target):.1f} kg"
+        label = f"{label_prefix} {idx} : {float(target):.1f} kg"
         fig.add_scatter(
             x=x_range,
             y=[float(target), float(target)],
@@ -87,7 +88,7 @@ def _add_single_target_line(fig: go.Figure, target: float, x_values: pd.Series |
     """Add the single objective used by the default dashboard view."""
     if len(x_values) == 0:
         return
-    label = f"Objectif principal: {float(target):.1f} kg"
+    label = f"Objectif principal : {float(target):.1f} kg"
     fig.add_scatter(
         x=[x_values.min(), x_values.max()],
         y=[float(target), float(target)],
@@ -242,9 +243,10 @@ def _render_daily_overview(summary: dict, target_weight: float, trajectory_statu
             "Trajectoire cible",
             (
                 f"Objectif {_format_fr_kg(trajectory_status['final_target_weight'])} estimé autour du "
-                f"{trajectory_status['eta_date'].strftime('%d/%m/%Y')}, avec une trajectoire de "
-                f"-{_format_fr_kg(trajectory_status['weekly_loss_target'])}/semaine depuis le "
-                f"{trajectory_status['start_date'].strftime('%d/%m/%Y')}. "
+                f"{trajectory_status['eta_date'].strftime('%d/%m/%Y')}, sur la base d’une baisse de "
+                f"{_format_fr_kg(trajectory_status['weekly_loss_target'])} par semaine depuis le "
+                f"{trajectory_status['start_date'].strftime('%d/%m/%Y')} à "
+                f"{_format_fr_kg(trajectory_status['start_weight'])}. "
                 f"{_trajectory_position_sentence(trajectory_status)}"
             ),
             tone="success" if trajectory_status.get("status") in {"avance", "aligné"} else "warning",
@@ -440,7 +442,8 @@ def _render_main_weight_chart(
             show_forecast = st.checkbox("Trajectoire cible", value=True)
             st.caption("Les objectifs et la trajectoire font partie de la lecture par défaut ; désactivez-les ici si besoin.")
             st.caption(
-                f"Paramètres trajectoire : départ {trajectory_config.start_date.strftime('%d/%m/%Y')} · "
+                f"Paramètres trajectoire : départ {trajectory_config.start_date.strftime('%d/%m/%Y')} "
+                f"à {_format_fr_kg(trajectory_config.start_weight)} · "
                 f"-{trajectory_config.weekly_loss_target:g} kg/sem · objectif {trajectory_config.final_target_weight:g} kg"
             )
 
@@ -457,7 +460,7 @@ def _render_main_weight_chart(
         name="Poids mesuré",
         line=dict(color="#2563eb", width=2.4, shape="spline", smoothing=0.35),
         marker=dict(size=5, color="#2563eb", line=dict(width=1, color="#ffffff")),
-        hovertemplate="%{x|%d/%m/%Y}<br>Poids: %{y:.2f} kg<extra></extra>",
+        hovertemplate="Date : %{x|%d/%m/%Y}<br>Poids mesuré : %{y:.2f} kg<extra></extra>",
     )
     if show_moving_average:
         fig.add_scatter(
@@ -466,7 +469,7 @@ def _render_main_weight_chart(
             mode="lines",
             name=ma_label,
             line=dict(color="rgba(100,116,139,0.62)", width=1.35, dash="dot"),
-            hovertemplate=f"%{{x|%d/%m/%Y}}<br>{ma_label}: %{{y:.2f}} kg<extra></extra>",
+            hovertemplate=f"Date : %{{x|%d/%m/%Y}}<br>{ma_label} : %{{y:.2f}} kg<extra></extra>",
         )
     _add_single_target_line(fig, target_weight, df["Date"])
 
@@ -484,7 +487,7 @@ def _render_main_weight_chart(
             mode="lines",
             name=f"Tendance long terme EMA ({trend_span})",
             line=dict(color="#f97316", width=2.2, dash="dot"),
-            hovertemplate="%{x|%d/%m/%Y}<br>Tendance: %{y:.2f} kg<extra></extra>",
+            hovertemplate="Date : %{x|%d/%m/%Y}<br>Tendance long terme : %{y:.2f} kg<extra></extra>",
         )
 
     target_trajectory = build_target_trajectory(df, trajectory_config)
@@ -496,14 +499,8 @@ def _render_main_weight_chart(
             y=trajectory_df["Poids cible (kg)"],
             mode="lines",
             name=label,
-            line=dict(color="rgba(20,184,166,0.78)", width=1.7, dash="dashdot"),
-            hovertemplate=(
-                "Date: %{x|%d/%m/%Y}<br>"
-                "Poids cible: %{y:.1f} kg<br>"
-                f"Départ: {target_trajectory['start_weight']:.1f} kg "
-                f"({target_trajectory['start_measurement_date'].strftime('%d/%m/%Y')})<br>"
-                f"Objectif final: {trajectory_config.final_target_weight:g} kg<extra></extra>"
-            ),
+            line=dict(color="#0f766e", width=2.35, dash="dashdot"),
+            hovertemplate="Date : %{x|%d/%m/%Y}<br>Trajectoire cible : %{y:.1f} kg<extra></extra>",
         )
 
     fig.update_layout(xaxis_title="Date", yaxis_title="Poids (kg)")
@@ -514,30 +511,23 @@ def _render_main_weight_chart(
 
 
 def _trajectory_config_controls() -> TargetTrajectoryConfig:
-    """Expose explicit business parameters with required defaults."""
+    """Return the fixed business trajectory configuration and document it in the sidebar."""
     with st.sidebar.expander("Trajectoire cible", expanded=False):
-        start_date = st.date_input(
-            "Date de départ de trajectoire",
-            value=DEFAULT_TARGET_TRAJECTORY_START_DATE.date(),
-            help="Par défaut : 01/06/2026. La courbe ne démarre pas avant cette date ni à aujourd’hui.",
+        st.caption(
+            "La trajectoire cible est ancrée sur la mesure de référence du "
+            f"{DEFAULT_TARGET_TRAJECTORY_START_DATE.strftime('%d/%m/%Y')} à "
+            f"{_format_fr_kg(DEFAULT_TARGET_TRAJECTORY_START_WEIGHT)}."
         )
-        weekly_loss_target = st.number_input(
-            "Rythme cible (kg/semaine)",
-            min_value=0.1,
-            max_value=10.0,
-            value=float(DEFAULT_WEEKLY_LOSS_TARGET),
-            step=0.1,
-            help="Saisir une valeur positive : 2 signifie une perte cible de 2 kg par semaine.",
+        st.caption(
+            f"Elle descend de {_format_fr_kg(DEFAULT_WEEKLY_LOSS_TARGET)} par semaine "
+            f"et s’arrête à {_format_fr_kg(DEFAULT_FINAL_TARGET_WEIGHT)}."
         )
-        final_target_weight = st.number_input(
-            "Objectif final (kg)",
-            min_value=30.0,
-            max_value=250.0,
-            value=float(DEFAULT_FINAL_TARGET_WEIGHT),
-            step=0.5,
-            help="Par défaut : 80 kg. La trajectoire s’arrête à cet objectif et ne descend pas en dessous.",
-        )
-    return TargetTrajectoryConfig.from_values(start_date, weekly_loss_target, final_target_weight)
+    return TargetTrajectoryConfig.from_values(
+        DEFAULT_TARGET_TRAJECTORY_START_DATE,
+        DEFAULT_WEEKLY_LOSS_TARGET,
+        DEFAULT_FINAL_TARGET_WEIGHT,
+        start_weight=DEFAULT_TARGET_TRAJECTORY_START_WEIGHT,
+    )
 
 def main() -> None:
     df = _df()

--- a/tests/test_target_trajectory.py
+++ b/tests/test_target_trajectory.py
@@ -5,6 +5,7 @@ import pandas as pd
 from app.core.target_trajectory import (
     DEFAULT_FINAL_TARGET_WEIGHT,
     DEFAULT_TARGET_TRAJECTORY_START_DATE,
+    DEFAULT_TARGET_TRAJECTORY_START_WEIGHT,
     DEFAULT_WEEKLY_LOSS_TARGET,
     TargetTrajectoryConfig,
     build_target_trajectory,
@@ -12,7 +13,7 @@ from app.core.target_trajectory import (
 )
 
 
-def test_target_trajectory_starts_on_fixed_date_uses_exact_measurement_and_stops_at_80():
+def test_target_trajectory_starts_on_fixed_reference_point_and_stops_at_80():
     df = pd.DataFrame(
         {
             "Date": pd.to_datetime(["2025-01-01", "2026-06-01", "2026-06-10"]),
@@ -26,17 +27,17 @@ def test_target_trajectory_starts_on_fixed_date_uses_exact_measurement_and_stops
     assert result["available"] is True
     assert result["start_date"] == DEFAULT_TARGET_TRAJECTORY_START_DATE
     assert result["start_measurement_date"] == DEFAULT_TARGET_TRAJECTORY_START_DATE
-    assert result["start_weight"] == 105.0
+    assert result["start_weight"] == DEFAULT_TARGET_TRAJECTORY_START_WEIGHT
     assert trajectory["Date"].iloc[0] == DEFAULT_TARGET_TRAJECTORY_START_DATE
-    assert trajectory["Poids cible (kg)"].iloc[0] == 105.0
+    assert trajectory["Poids cible (kg)"].iloc[0] == DEFAULT_TARGET_TRAJECTORY_START_WEIGHT
     assert trajectory["Poids cible (kg)"].min() == DEFAULT_FINAL_TARGET_WEIGHT
     assert trajectory["Poids cible (kg)"].iloc[-1] == DEFAULT_FINAL_TARGET_WEIGHT
-    assert math.isclose(result["target_days"], 87.5)
-    assert result["eta_date"] == DEFAULT_TARGET_TRAJECTORY_START_DATE + pd.Timedelta(days=87.5)
+    assert math.isclose(result["target_days"], 91.7)
+    assert result["eta_date"] == DEFAULT_TARGET_TRAJECTORY_START_DATE + pd.Timedelta(days=91.7)
     assert trajectory["Date"].iloc[-1] == result["eta_date"]
 
 
-def test_target_trajectory_uses_nearest_measurement_to_fixed_start_date():
+def test_target_trajectory_does_not_infer_start_from_nearby_measurements():
     df = pd.DataFrame(
         {
             "Date": pd.to_datetime(["2026-05-29", "2026-06-04"]),
@@ -46,34 +47,40 @@ def test_target_trajectory_uses_nearest_measurement_to_fixed_start_date():
 
     result = build_target_trajectory(df)
 
-    assert result["start_date"] == DEFAULT_TARGET_TRAJECTORY_START_DATE
-    assert result["start_measurement_date"] == pd.Timestamp("2026-05-29")
-    assert result["start_weight"] == 106.0
+    assert result["start_date"] == pd.Timestamp("2026-05-26")
+    assert result["start_measurement_date"] == pd.Timestamp("2026-05-26")
+    assert result["start_weight"] == 106.2
 
 
 def test_compare_to_target_trajectory_reports_gap_status_and_progress():
     df = pd.DataFrame(
         {
-            "Date": pd.to_datetime(["2026-06-01", "2026-06-08"]),
-            "Poids (Kgs)": [105.0, 104.0],
+            "Date": pd.to_datetime(["2026-05-26", "2026-06-02"]),
+            "Poids (Kgs)": [106.2, 105.0],
         }
     )
 
     result = compare_to_target_trajectory(df)
 
-    assert result["scheduled_weight"] == 103.0
-    assert result["gap_kg"] == 1.0
+    assert result["scheduled_weight"] == 104.2
+    assert math.isclose(result["gap_kg"], 0.8)
     assert result["status"] == "retard"
-    assert result["progress_pct"] == 4.0
+    assert math.isclose(result["progress_pct"], (106.2 - 105.0) / 26.2 * 100)
 
 
 def test_target_trajectory_supports_explicit_business_parameters():
     df = pd.DataFrame({"Date": pd.to_datetime(["2026-07-01"]), "Poids (Kgs)": [90.0]})
-    config = TargetTrajectoryConfig.from_values("2026-07-01", weekly_loss_target=1.0, final_target_weight=85.0)
+    config = TargetTrajectoryConfig.from_values(
+        "2026-07-01",
+        weekly_loss_target=1.0,
+        final_target_weight=85.0,
+        start_weight=90.0,
+    )
 
     result = build_target_trajectory(df, config)
 
     assert result["start_date"] == pd.Timestamp("2026-07-01")
+    assert result["start_weight"] == 90.0
     assert result["weekly_loss_target"] == 1.0
     assert result["final_target_weight"] == 85.0
     assert math.isclose(result["target_days"], 35.0)


### PR DESCRIPTION
### Motivation

- Anchor the target trajectory to the explicit business reference point requested: start on `2026-05-26` at `106.2 kg` rather than inferring a start from nearby measurements or averages. 

### Description

- Replace the previous nearest-measurement logic with a fixed reference and configuration: added `DEFAULT_TARGET_TRAJECTORY_START_WEIGHT`, `TargetTrajectoryConfig.start_weight`, and `fixed_start_measurement`, and the trajectory is now sourced from `config.start_date`/`config.start_weight` (files changed: `app/core/target_trajectory.py`, `app/pages/Dashboard.py`).
- Keep the descent rate at `-2 kg / semaine` (daily = `2/7` kg/day), compute ETA from the fixed start weight to `80 kg`, cap the curve at `80 kg` and stop the series when the target is reached (`app/core/target_trajectory.py`).
- Update the dashboard copy and visuals: show the fixed start point in the sidebar, simplify the trajectory tooltip to `Trajectoire cible : X kg`, make the curve visually distinct, and improve hover text wording for other traces (`app/pages/Dashboard.py`).
- Update tests and docs: adjust `tests/test_target_trajectory.py` to assert the fixed start, ETA (~`91.7` days), stopping at `80 kg`, and update `README.md` feature line describing the fixed trajectory.

### Testing

- `python -m py_compile app/core/target_trajectory.py app/pages/Dashboard.py tests/test_target_trajectory.py` completed successfully. 
- `python -m compileall app tests` completed successfully and the modified modules compile cleanly. 
- Running the full test suite with `pytest ...` was attempted but blocked by the environment with `ModuleNotFoundError: No module named 'numpy'`. 
- Installing requirements with `python -m pip install -r requirements.txt` was blocked by network/index errors (403 on `matplotlib==3.8.4`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26bd8187f48329b0f37be7e4941df1)