### PR TITLE
Polish dashboard summary and automatic insights UX

### DIFF
--- a/app/core/analytics.py
+++ b/app/core/analytics.py
@@ -912,6 +912,21 @@ def generate_insights_text(df: pd.DataFrame, target_weight: float) -> list[str]:
     return insights if insights else ["📊 Analyses en cours, continuez à saisir vos données."]
 
 
+
+def _format_fr_number(value: float, decimals: int = 1, *, trim_zeros: bool = True) -> str:
+    formatted = f"{float(value):.{decimals}f}"
+    if trim_zeros:
+        formatted = formatted.rstrip("0").rstrip(".")
+    return formatted.replace(".", ",")
+
+
+def _format_fr_kg(value: float, decimals: int = 1, *, trim_zeros: bool = True) -> str:
+    return f"{_format_fr_number(value, decimals=decimals, trim_zeros=trim_zeros)} kg"
+
+
+def _format_fr_weekly_pace(value: float, decimals: int = 1) -> str:
+    return f"{_format_fr_number(abs(value), decimals=decimals)} kg par semaine"
+
 # ---------------------------------------------------------------------------
 # 18b. Résumé actionnable : Situation / Interprétation / Action
 # ---------------------------------------------------------------------------
@@ -948,21 +963,30 @@ def generate_action_summary(df: pd.DataFrame, target_weight: float) -> dict[str,
     # ── SITUATION (factuelle) ──
     if effort["is_subset"]:
         if delta > 0:
-            situation = f"Vous avez repris le suivi le {start_str} — **-{delta:.1f} kg** en {effort_days} jours ({effort_measurements} mesures)."
+            situation = (
+                f"Depuis la reprise du suivi le {start_str}, vous avez perdu "
+                f"{_format_fr_kg(delta)} en {effort_days} jours, sur {effort_measurements} mesures."
+            )
         elif delta < 0:
-            situation = f"Vous avez repris le suivi le {start_str} — **+{abs(delta):.1f} kg** en {effort_days} jours ({effort_measurements} mesures)."
+            situation = (
+                f"Depuis la reprise du suivi le {start_str}, votre poids a augmenté de "
+                f"{_format_fr_kg(abs(delta))} en {effort_days} jours, sur {effort_measurements} mesures."
+            )
         else:
-            situation = f"Vous avez repris le suivi le {start_str} — poids stable ({effort_measurements} mesures)."
+            situation = (
+                f"Depuis la reprise du suivi le {start_str}, votre poids est resté stable "
+                f"sur {effort_measurements} mesures."
+            )
     else:
-        situation = f"Suivi continu depuis le {start_str} — {len(df)} mesures."
+        situation = f"Suivi continu depuis le {start_str}, avec {len(df)} mesures enregistrées."
 
     # ── INTERPRÉTATION (ce que ça veut dire) ──
     if is_startup:
         if delta > 1.5:
             interpretation = (
-                f"Cette perte rapide ({delta:.1f} kg en {effort_days}j) est très probablement de l'eau "
-                f"et de la vidange digestive. **Ce n'est pas de la graisse.** "
-                f"La vraie tendance se vérifiera à partir du jour 7-10."
+                f"Cette perte rapide ({_format_fr_kg(delta)} en {effort_days} jours) est probablement liée "
+                f"en partie aux variations d'eau et de digestion. La tendance réelle se confirmera "
+                f"à partir de 7 à 10 jours de suivi."
             )
         elif delta > 0:
             interpretation = (
@@ -971,7 +995,7 @@ def generate_action_summary(df: pd.DataFrame, target_weight: float) -> dict[str,
             )
         elif delta < 0:
             interpretation = (
-                f"Reprise de {abs(delta):.1f} kg en début de suivi. "
+                f"Votre poids a augmenté de {_format_fr_kg(abs(delta))} en début de suivi. "
                 f"Les premiers jours sont souvent bruités — attendez le jour 7 pour évaluer."
             )
         else:
@@ -981,13 +1005,25 @@ def generate_action_summary(df: pd.DataFrame, target_weight: float) -> dict[str,
         vel = weight_velocity(effort_df, windows=(7,))
         v7 = vel.get(7)
         if v7 is not None and v7 < -1.0:
-            interpretation = f"Perte soutenue de **{v7:.2f} kg/sem** — rythme rapide mais tenable si bien encadré."
+            interpretation = (
+                f"Votre rythme récent est d’environ {_format_fr_weekly_pace(v7)}. "
+                f"C’est une baisse soutenue : vérifiez qu’elle reste compatible avec votre énergie et votre régularité."
+            )
         elif v7 is not None and v7 < -0.3:
-            interpretation = f"Perte régulière de **{v7:.2f} kg/sem** — c'est le rythme idéal pour une perte durable."
+            interpretation = (
+                f"Votre rythme récent est d’environ {_format_fr_weekly_pace(v7)}. "
+                f"C’est une tendance progressive et plus facile à maintenir."
+            )
         elif v7 is not None and v7 < 0:
-            interpretation = f"Perte lente ({v7:.2f} kg/sem) mais dans la bonne direction. La patience paie."
+            interpretation = (
+                f"Votre poids baisse lentement, autour de {_format_fr_weekly_pace(v7)}. "
+                f"La tendance reste dans la bonne direction."
+            )
         elif v7 is not None and v7 > 0.5:
-            interpretation = f"Reprise récente de **+{v7:.2f} kg/sem**. Vérifiez si c'est du bruit ou une tendance."
+            interpretation = (
+                f"Votre poids remonte récemment, autour de {_format_fr_weekly_pace(v7)}. "
+                f"Vérifiez si cela correspond à quelques fluctuations ou à une tendance qui s’installe."
+            )
         elif v7 is not None and v7 > 0:
             interpretation = "Légère remontée récente — probablement des fluctuations naturelles."
         else:
@@ -998,25 +1034,28 @@ def generate_action_summary(df: pd.DataFrame, target_weight: float) -> dict[str,
 
     if is_startup:
         action = (
-            f"**Cette semaine** : pesez-vous chaque matin à jeun. "
-            f"L'objectif n'est pas la perte mais la régularité du suivi. "
-            f"Les analyses fiables arrivent au jour 7."
+            f"Cette semaine : pesez-vous chaque matin à jeun. "
+            f"L’objectif est de consolider la régularité du suivi avant d’interpréter la tendance."
         )
     elif remaining > 20:
+        next_step = int(current / 5) * 5
         action = (
-            f"**Prochain objectif** : passer sous {int(current / 5) * 5} kg. "
-            f"Concentrez-vous sur la constance du suivi quotidien."
+            f"Prochain objectif : passer sous {_format_fr_kg(next_step, trim_zeros=True)}. "
+            f"Continuez à suivre votre poids régulièrement pour confirmer la tendance."
         )
     elif remaining > 5:
         ms_target = int(current) if int(current) < current else int(current) - 1
         action = (
-            f"**Prochain palier** : {ms_target} kg (reste {current - ms_target:.1f} kg). "
-            f"Maintenez le rythme actuel."
+            f"Prochain palier : {_format_fr_kg(ms_target, trim_zeros=True)}. "
+            f"Il reste {_format_fr_kg(current - ms_target)} pour l’atteindre ; maintenez votre régularité."
         )
     elif remaining > 0:
-        action = f"**Vous approchez de l'objectif** ({remaining:.1f} kg restants). Gardez le cap !"
+        action = (
+            f"Vous approchez de l’objectif : il reste {_format_fr_kg(remaining)}. "
+            f"Gardez le cap et continuez le suivi régulier."
+        )
     else:
-        action = "**Objectif atteint !** Passez en mode maintien — l'enjeu est de rester stable."
+        action = "Objectif atteint. Passez en mode maintien : l’enjeu est de rester stable dans la durée."
 
     return {
         "situation": situation,

--- a/app/core/weight_summary.py
+++ b/app/core/weight_summary.py
@@ -55,6 +55,36 @@ def prepare_weight_series(df: pd.DataFrame) -> pd.DataFrame:
     return out.reset_index(drop=True)
 
 
+def format_fr_number(value: float, decimals: int = 1, *, trim_zeros: bool = True) -> str:
+    formatted = f"{float(value):.{decimals}f}"
+    if trim_zeros:
+        formatted = formatted.rstrip("0").rstrip(".")
+    return formatted.replace(".", ",")
+
+
+def format_fr_kg(value: float, decimals: int = 1, *, trim_zeros: bool = True) -> str:
+    return f"{format_fr_number(value, decimals=decimals, trim_zeros=trim_zeros)} kg"
+
+
+def _format_delta_text(delta: float) -> str:
+    if delta < 0:
+        return f"baisse de {format_fr_kg(abs(delta))}"
+    if delta > 0:
+        return f"hausse de {format_fr_kg(delta)}"
+    return "variation stable"
+
+
+def _current_tracking_period(df: pd.DataFrame, gap_threshold_days: int = 21) -> pd.DataFrame:
+    data = prepare_weight_series(df)
+    if len(data) < 2:
+        return data
+    gaps = data[DATE_COL].diff().dt.days.fillna(0)
+    restart_positions = gaps[gaps > gap_threshold_days].index
+    if len(restart_positions) == 0:
+        return data
+    return data.iloc[int(restart_positions[-1]) :].reset_index(drop=True)
+
+
 def moving_average_by_days(df: pd.DataFrame, days: int) -> pd.Series:
     """Calendar-aware moving average, robust to irregular measurements."""
     if df.empty:
@@ -204,47 +234,66 @@ def generate_daily_insights(df: pd.DataFrame, target_weight: float) -> list[str]
     """Generate short, non-alarmist insights for the dashboard."""
     data = prepare_weight_series(df)
     if data.empty:
-        return ["Aucune mesure valide n'est disponible pour générer des insights."]
+        return ["Aucune mesure valide n’est disponible pour générer des insights."]
     if len(data) == 1:
         return ["Ajoutez au moins une deuxième mesure pour calculer les variations."]
 
     current = float(data[WEIGHT_COL].iloc[-1])
-    first = float(data[WEIGHT_COL].iloc[0])
-    delta_total = current - first
     delta_7 = delta_since_days(data, 7)
     delta_30 = delta_since_days(data, 30)
     trend, explanation = classify_trend(delta_30, delta_7)
+    target_weight = float(target_weight)
 
-    insights = [explanation]
+    insights: list[str] = []
+    recent_period = _current_tracking_period(data)
+    if len(recent_period) >= 2:
+        recent_delta = float(recent_period[WEIGHT_COL].iloc[-1] - recent_period[WEIGHT_COL].iloc[0])
+        recent_days = int((recent_period[DATE_COL].iloc[-1] - recent_period[DATE_COL].iloc[0]).days)
+        start_str = recent_period[DATE_COL].iloc[0].strftime("%d/%m/%Y")
+        if recent_period[DATE_COL].iloc[0] > data[DATE_COL].iloc[0]:
+            insights.append(
+                f"Depuis la reprise du {start_str}, votre poids affiche une {_format_delta_text(recent_delta)} "
+                f"en {recent_days} jours."
+            )
+
+    if not insights:
+        if delta_7.value is not None:
+            insights.append(f"Sur 7 jours, votre poids affiche une {_format_delta_text(delta_7.value)}.")
+        else:
+            insights.append(explanation)
+
     if delta_30.value is not None:
         if delta_30.value < -0.3:
-            insights.append("Ton poids baisse progressivement sur les 30 derniers jours disponibles.")
+            insights.append(f"Sur 30 jours, la tendance reste orientée à la baisse ({format_fr_kg(abs(delta_30.value))}).")
         elif delta_30.value > 0.3:
-            insights.append("Attention, les dernières mesures montrent une légère reprise sur environ 30 jours.")
+            insights.append(f"Sur 30 jours, les dernières mesures montrent une hausse de {format_fr_kg(delta_30.value)}.")
         else:
-            insights.append("La tendance est stable sur les 30 derniers jours disponibles.")
+            insights.append("Sur 30 jours, votre poids reste globalement stable.")
     elif delta_7.value is not None and abs(delta_7.value) <= 0.25:
-        insights.append("La tendance est stable cette semaine.")
+        insights.append("Sur 7 jours, la variation reste faible : continuez le suivi pour confirmer la tendance.")
 
-    if abs(delta_total) >= 0.2:
-        direction = "perdu" if delta_total < 0 else "pris"
-        insights.append(f"Depuis le début du suivi, tu as {direction} {abs(delta_total):.1f} kg.")
+    next_step = math.floor(current / 5) * 5
+    if current > next_step and next_step > target_weight:
+        insights.append(f"Prochain palier : passer sous {format_fr_kg(next_step, trim_zeros=True)}.")
 
-    gap = current - float(target_weight)
+    gap = current - target_weight
     if gap > 0:
-        insights.append(f"Il reste {gap:.1f} kg avant l'objectif final configuré.")
+        insights.append(f"Il reste {format_fr_kg(gap)} avant l’objectif final configuré.")
     else:
-        insights.append("L'objectif final configuré est atteint ou dépassé.")
+        insights.append("L’objectif final configuré est atteint ou dépassé.")
 
+    has_significant_drop = (delta_7.value is not None and delta_7.value <= -0.3) or (
+        delta_30.value is not None and delta_30.value <= -0.5
+    )
     periods = detect_stagnation_periods(data)
-    if periods:
+    if periods and trend != "Baisse" and not has_significant_drop:
         last = periods[-1]
         insights.append(
-            f"Période de stagnation possible : {last['days']} jours avec seulement {last['amplitude']:.1f} kg d'amplitude."
+            f"Stabilité possible : {last['days']} jours avec une amplitude limitée à {format_fr_kg(last['amplitude'])}."
         )
 
     if trend == "À confirmer":
-        insights.append("Les calculs restent prudents car l'historique récent est encore limité.")
+        insights.append("Les calculs restent prudents car l’historique récent est encore limité.")
     return insights[:5]
 
 

--- a/app/pages/Dashboard.py
+++ b/app/pages/Dashboard.py
@@ -378,11 +378,51 @@ def _render_advanced_kpis(
     return analysis_df, prog, streaks
 
 
+def _daily_insight_title(body: str, position: int) -> str:
+    text = body.lower()
+    if "7 jours" in text:
+        return "Tendance 7 jours"
+    if "30 jours" in text or "reprise" in text:
+        return "Évolution récente"
+    if "palier" in text or "passer sous" in text:
+        return "Prochain palier"
+    if "objectif final" in text or "objectif configuré" in text:
+        return "Distance à l’objectif"
+    if "stabilité" in text or "stable" in text:
+        return "Stabilité du poids"
+    if "trajectoire" in text:
+        return "Écart à la trajectoire"
+    fallback_titles = ("Tendance récente", "Distance au prochain palier", "Analyse complémentaire")
+    return fallback_titles[min(position, len(fallback_titles) - 1)]
+
+
+def _daily_insight_tone(body: str, default_tone: str) -> str:
+    text = body.lower()
+    if "baisse" in text or "perdu" in text:
+        return "success"
+    if "hausse" in text or "remonte" in text or "attention" in text:
+        return "warning"
+    if "objectif" in text or "palier" in text:
+        return "info"
+    return default_tone
+
+
 def _render_simple_insights(summary: dict) -> None:
-    section_header("Insights automatiques", "Commentaires simples, non médicaux, pour comprendre la tendance sans sur-interpréter.", "💡")
+    section_header("Insights automatiques", "Les 3 signaux les plus utiles pour suivre la tendance actuelle.", "💡")
     trend_tone = {"Baisse": "success", "Hausse": "warning", "Stable": "info"}.get(summary.get("trend_label"), "neutral")
-    for idx, insight in enumerate(summary.get("insights", []), start=1):
-        insight_card(f"Signal {idx}", insight, tone=trend_tone if idx == 1 else "info", icon="📉" if trend_tone == "success" else "📈" if trend_tone == "warning" else "🔎")
+    insights = [str(item).replace("**", "") for item in summary.get("insights", []) if str(item).strip()]
+    primary_insights = insights[:3]
+    detailed_insights = insights[3:]
+
+    for idx, insight in enumerate(primary_insights):
+        tone = _daily_insight_tone(insight, trend_tone if idx == 0 else "neutral")
+        icon = "📉" if tone == "success" else "📈" if tone == "warning" else "🎯" if "objectif" in insight.lower() or "palier" in insight.lower() else "🔎"
+        insight_card(_daily_insight_title(insight, idx), insight, tone=tone, icon=icon)
+
+    if detailed_insights:
+        with st.expander("Voir les analyses détaillées", expanded=False):
+            for idx, insight in enumerate(detailed_insights, start=len(primary_insights)):
+                insight_card(_daily_insight_title(insight, idx), insight, tone=_daily_insight_tone(insight, "neutral"), icon="🔎")
 
 
 def _render_objective_gap_chart(df: pd.DataFrame, target_weight: float) -> None:
@@ -561,7 +601,7 @@ def main() -> None:
         "Suivi de poids",
         "Dashboard",
         "Un tableau de bord allégé pour lire immédiatement le poids actuel, la tendance récente et l’écart à l’objectif.",
-        meta=f"Dernière mesure : {last_date.strftime('%d/%m/%Y')} · {len(df)} mesure(s) · objectif principal {target_weight:.1f} kg",
+        meta=f"Dernière mesure : {last_date.strftime('%d/%m/%Y')} · {len(df)} mesure(s) · objectif principal {_format_fr_kg(target_weight)}",
     )
 
     if daily_summary.get("valid"):
@@ -573,11 +613,16 @@ def main() -> None:
         effort_initial = float(effort_df["Poids (Kgs)"].iloc[0])
         effort_delta = effort_initial - current
         delta_icon = "📉" if effort_delta > 0 else "📈" if effort_delta < 0 else "➡️"
-        delta_text = f"-{effort_delta:.1f}" if effort_delta > 0 else f"+{abs(effort_delta):.1f}"
+        if effort_delta > 0:
+            delta_text = f"-{_format_fr_kg(effort_delta)}"
+        elif effort_delta < 0:
+            delta_text = f"+{_format_fr_kg(abs(effort_delta))}"
+        else:
+            delta_text = _format_fr_kg(0)
         st.info(
             f"📅 **Période d’effort actuelle** : depuis le {effort_start.strftime('%d/%m/%Y')} "
             f"({effort_days} jours, {effort_measurements} mesures) — "
-            f"{delta_icon} **{delta_text} kg** ({effort_initial:.1f} → {current:.1f} kg)"
+            f"{delta_icon} **{delta_text}** ({_format_fr_kg(effort_initial)} → {_format_fr_kg(current)})"
         )
 
     _render_main_weight_chart(df, target_weight, targets, effort_df, effort_start, effort_days, has_effort_period, trajectory_config)

--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -179,20 +179,21 @@ def apply_global_theme() -> None:
         }
         .suivi-insight-card, .suivi-progress-panel {
             display: flex;
-            gap: 0.8rem;
+            gap: 0.65rem;
             align-items: flex-start;
-            padding: 1rem;
-            margin: 0.45rem 0;
+            padding: 0.68rem 0.78rem;
+            margin: 0.32rem 0;
             border: 1px solid var(--suivi-border);
-            border-radius: 20px;
+            border-radius: 16px;
             background: var(--suivi-card);
-            box-shadow: 0 10px 24px rgba(15,23,42,0.045);
+            box-shadow: 0 6px 16px rgba(15,23,42,0.035);
         }
-        .suivi-insight-card p, .suivi-progress-panel p {margin: 0.25rem 0 0 0; color: var(--suivi-muted); line-height: 1.45;}
-        .suivi-insight-icon {font-size: 1.35rem; line-height: 1;}
-        .suivi-insight-success {border-color: rgba(22,163,74,0.22); background: linear-gradient(135deg, #ffffff, var(--suivi-green-soft));}
-        .suivi-insight-warning {border-color: rgba(249,115,22,0.25); background: linear-gradient(135deg, #ffffff, var(--suivi-orange-soft));}
-        .suivi-insight-info {border-color: rgba(37,99,235,0.20); background: linear-gradient(135deg, #ffffff, var(--suivi-blue-soft));}
+        .suivi-insight-card strong {font-size: 0.93rem; line-height: 1.2;}
+        .suivi-insight-card p, .suivi-progress-panel p {margin: 0.16rem 0 0 0; color: var(--suivi-muted); line-height: 1.32; font-size: 0.92rem;}
+        .suivi-insight-icon {font-size: 1.08rem; line-height: 1.15; opacity: 0.9;}
+        .suivi-insight-success {border-left: 3px solid var(--suivi-green);}
+        .suivi-insight-warning {border-left: 3px solid var(--suivi-orange);}
+        .suivi-insight-info {border-left: 3px solid var(--suivi-blue);}
         .suivi-progress-panel {display: block;}
         .suivi-progress-top {display: flex; justify-content: space-between; gap: 1rem; align-items: center;}
         .suivi-progress-top span {font-size: 1.25rem; font-weight: 900; color: var(--suivi-blue);}


### PR DESCRIPTION
### Motivation
- Remove raw Markdown (`**`) visible in UI, unify wording to the French vouvoiement, and present numerical values using French formatting (comma decimals, space before `kg`).
- Make automatic insights more useful by prioritizing recent tracking periods (7d/30d) and avoiding misleading global-history statements as primary signals.
- Avoid contradictory insights (e.g., showing both “baisse” and “stagnation”) and reduce visual weight of insight cards for a more compact, professional dashboard.

### Description
- Rewrote the 3-part dashboard summary wording in `generate_action_summary` to use natural French sentences, remove inline `**` markers and use formatting helpers (`_format_fr_kg`, `_format_fr_weekly_pace`) for French number/units (file: `app/core/analytics.py`).
- Reworked daily automatic insights in `generate_daily_insights` to prefer the current tracking period, surface clear 7-day/30-day messages, suppress global "depuis le début" as a primary insight, and avoid showing stagnation when recent loss is significant (file: `app/core/weight_summary.py`).
- Replaced generic "Signal 1/2/3" cards by explicit titles and tones via `_daily_insight_title` and `_daily_insight_tone`, limited visible insights to 3 and moved extras into an expander (file: `app/pages/Dashboard.py`).
- Made the insight card UI lighter and more compact by reducing padding/margins, decreasing icon size, simplifying colors to left borders, and adjusting typography (file: `app/ui/theme.py`).

### Testing
- Ran code compilation with `python3 -m compileall app/core/analytics.py app/core/weight_summary.py app/pages/Dashboard.py app/ui/theme.py`, which completed successfully.
- Attempted to run unit tests with `pytest -q tests/test_weight_summary.py`, but test collection failed due to missing environment dependency `numpy` in the execution environment, so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26c014299483299d89326b7d8a6571)